### PR TITLE
Refactor evaluation to not be in place

### DIFF
--- a/benches/eval.rs
+++ b/benches/eval.rs
@@ -18,31 +18,31 @@ fn compile(input: &str) -> LangResult<Term> {
 fn arithmetic(c: &mut Criterion) {
     let input = include_str!("../tests/eval/arithmetic.pj");
     let term = compile(input).unwrap();
-    c.bench_function("arithmetic", |b| b.iter(|| evaluate(term.clone()).unwrap()));
+    c.bench_function("arithmetic", |b| b.iter(|| evaluate(term.clone())));
 }
 
 fn fact_rec(c: &mut Criterion) {
     let input = include_str!("../tests/eval/fact_rec.pj");
     let term = compile(input).unwrap();
-    c.bench_function("fact_rec", |b| b.iter(|| evaluate(term.clone()).unwrap()));
+    c.bench_function("fact_rec", |b| b.iter(|| evaluate(term.clone())));
 }
 
 fn fact_tail(c: &mut Criterion) {
     let input = include_str!("../tests/eval/fact_tail.pj");
     let term = compile(input).unwrap();
-    c.bench_function("fact_tail", |b| b.iter(|| evaluate(term.clone()).unwrap()));
+    c.bench_function("fact_tail", |b| b.iter(|| evaluate(term.clone())));
 }
 
 fn fancy_max(c: &mut Criterion) {
     let input = include_str!("../tests/eval/fancy_max.pj");
     let term = compile(input).unwrap();
-    c.bench_function("fancy_max", |b| b.iter(|| evaluate(term.clone()).unwrap()));
+    c.bench_function("fancy_max", |b| b.iter(|| evaluate(term.clone())));
 }
 
 fn step(c: &mut Criterion) {
     let input = include_str!("../tests/eval/step.pj");
     let term = compile(input).unwrap();
-    c.bench_function("step", |b| b.iter(|| evaluate(term.clone()).unwrap()));
+    c.bench_function("step", |b| b.iter(|| evaluate(term.clone())));
 }
 
 criterion_group!(benches, arithmetic, fact_rec, fact_tail, fancy_max, step);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,6 @@ pub enum LangError {
     #[error("{0}")]
     Ty(#[from] ty::TyError),
     #[error("{0}")]
-    Eval(#[from] lir::EvalError),
-    #[error("{0}")]
     Parse(String),
 }
 
@@ -25,6 +23,6 @@ pub fn run(input: &str) -> LangResult<lir::Term> {
     let mir = mir::Term::from_ast(ast);
     let _ty = ty::ty_check(&mir)?;
     let lir = lir::Term::from_mir(mir);
-    let res = lir::evaluate(lir)?;
+    let res = lir::evaluate(lir);
     Ok(res)
 }

--- a/src/lir.rs
+++ b/src/lir.rs
@@ -2,6 +2,9 @@ use std::fmt;
 
 use crate::ast::*;
 
+use Abstraction::*;
+use Term::*;
+
 mod ctx;
 
 pub fn evaluate(term: Term) -> Term {
@@ -17,7 +20,6 @@ pub enum Abstraction {
 
 impl fmt::Display for Abstraction {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use Abstraction::*;
         match self {
             Lambda(term) => write!(f, "(λ. {})", term),
             Binary(bin_op) => write!(f, "{}", bin_op),
@@ -40,13 +42,13 @@ pub enum Term {
 impl fmt::Display for Term {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Term::Hole => write!(f, "hole"),
-            Term::Var(var) => write!(f, "_{}", var),
-            Term::Abs(abs) => write!(f, "{}", abs),
-            Term::App(t1, t2) => write!(f, "({} {})", t1, t2),
-            Term::Lit(literal) => write!(f, "{}", literal),
-            Term::Cond(t1, t2, t3) => write!(f, "(if {} then {} else {})", t1, t2, t3),
-            Term::Fix(t1) => write!(f, "(fix {})", t1),
+            Hole => write!(f, "hole"),
+            Var(var) => write!(f, "_{}", var),
+            Abs(abs) => write!(f, "{}", abs),
+            App(t1, t2) => write!(f, "({} {})", t1, t2),
+            Lit(literal) => write!(f, "{}", literal),
+            Cond(t1, t2, t3) => write!(f, "(if {} then {} else {})", t1, t2, t3),
+            Fix(t1) => write!(f, "(fix {})", t1),
         }
     }
 }
@@ -58,8 +60,8 @@ impl Term {
 
     fn shift(&mut self, up: bool, cutoff: usize) {
         match self {
-            Term::Lit(_) | Term::Hole => (),
-            Term::Var(index) => {
+            Lit(_) | Hole => (),
+            Var(index) => {
                 if *index >= cutoff {
                     if up {
                         *index += 1;
@@ -68,22 +70,22 @@ impl Term {
                     }
                 }
             }
-            Term::Abs(abs) => match abs {
-                Abstraction::Lambda(body) => {
+            Abs(abs) => match abs {
+                Lambda(body) => {
                     body.shift(up, cutoff + 1);
                 }
-                Abstraction::Unary(_) | Abstraction::Binary(_) => (),
+                Unary(_) | Binary(_) => (),
             },
-            Term::App(t1, t2) => {
+            App(t1, t2) => {
                 t1.shift(up, cutoff);
                 t2.shift(up, cutoff);
             }
-            Term::Cond(t1, t2, t3) => {
+            Cond(t1, t2, t3) => {
                 t1.shift(up, cutoff);
                 t2.shift(up, cutoff);
                 t3.shift(up, cutoff);
             }
-            Term::Fix(t1) => {
+            Fix(t1) => {
                 t1.shift(up, cutoff);
             }
         }
@@ -91,37 +93,37 @@ impl Term {
 
     fn replace(&mut self, index: usize, subs: &mut Term) {
         match self {
-            Term::Lit(_) | Term::Hole => (),
-            Term::Var(index2) => {
+            Lit(_) | Hole => (),
+            Var(index2) => {
                 if index == *index2 {
                     *self = subs.clone();
                 }
             }
-            Term::Abs(abs) => match abs {
-                Abstraction::Lambda(body) => {
+            Abs(abs) => match abs {
+                Lambda(body) => {
                     subs.shift(true, 0);
                     body.replace(index + 1, subs);
                     subs.shift(false, 0);
                 }
-                Abstraction::Unary(_) | Abstraction::Binary(_) => (),
+                Unary(_) | Binary(_) => (),
             },
-            Term::App(t1, t2) => {
+            App(t1, t2) => {
                 t1.replace(index, subs);
                 t2.replace(index, subs);
             }
-            Term::Cond(t1, t2, t3) => {
+            Cond(t1, t2, t3) => {
                 t1.replace(index, subs);
                 t2.replace(index, subs);
                 t3.replace(index, subs);
             }
-            Term::Fix(t1) => {
+            Fix(t1) => {
                 t1.replace(index, subs);
             }
         }
     }
 
     fn step_in_place(&mut self) -> bool {
-        let term = std::mem::replace(self, Term::Hole);
+        let term = std::mem::replace(self, Hole);
         let (cont, term) = term.step();
         *self = term;
         cont
@@ -131,19 +133,15 @@ impl Term {
         match self {
             // Binary operations ((op t1) t2)
             // If t1 and t2 are literals, do the operation.
-            Term::App(
-                box Term::App(box Term::Abs(Abstraction::Binary(op)), box Term::Lit(l1)),
-                box Term::Lit(l2),
-            ) => (true, Term::Lit(eval_bin_op(op, l1, l2))),
+            App(box App(box Abs(Binary(op)), box Lit(l1)), box Lit(l2)) => {
+                (true, Lit(eval_bin_op(op, l1, l2)))
+            }
             // If t2 is not a literal, evaluate it.
-            Term::App(
-                box Term::App(box Term::Abs(Abstraction::Binary(_)), box Term::Lit(_)),
-                ref mut t2,
-            ) => (t2.step_in_place(), self),
+            App(box App(box Abs(Binary(_)), box Lit(_)), ref mut t2) => (t2.step_in_place(), self),
 
             // Beta Reduction ((\. b) t2)
             // Replace the argument of the function by t2 inside b and evaluate to b.
-            Term::App(box Term::Abs(Abstraction::Lambda(box mut body)), box mut t2) => {
+            App(box Abs(Lambda(box mut body)), box mut t2) => {
                 t2.shift(true, 0);
                 body.replace(0, &mut t2);
                 body.shift(false, 0);
@@ -152,46 +150,42 @@ impl Term {
 
             // Unary Operations (op t1)
             // If t1 is a literal, do the operation.
-            Term::App(box Term::Abs(Abstraction::Unary(op)), box Term::Lit(lit)) => {
-                (true, Term::Lit(eval_un_op(op, lit)))
-            }
+            App(box Abs(Unary(op)), box Lit(lit)) => (true, Lit(eval_un_op(op, lit))),
 
             // Application of abstraction with unevaluated parameter
             // This rule takes care of:
             // - Binary Operations ((op t1) t2) where t1 is not a literal.
             // - Unary Operations (op t1) where t1 is not a literal.
             // In both cases it evaluates t1.
-            Term::App(box Term::Abs(_), ref mut t) => (t.step_in_place(), self),
+            App(box Abs(_), ref mut t) => (t.step_in_place(), self),
 
             // Application with unevaluated first term (t1 t2)
             // Evaluate t1.
-            Term::App(ref mut t1, _) => (t1.step_in_place(), self),
+            App(ref mut t1, _) => (t1.step_in_place(), self),
 
             // Conditionals (if t1 then t2 else t3)
             // If t1 is true, evaluate to t2.
-            Term::Cond(box Term::Lit(Literal::True), box t2, _) => (true, t2),
+            Cond(box Lit(Literal::True), box t2, _) => (true, t2),
             // If t1 is false, evaluate to t3.
-            Term::Cond(box Term::Lit(Literal::False), _, box t3) => (true, t3),
+            Cond(box Lit(Literal::False), _, box t3) => (true, t3),
             // If t1 is any other literal, this is an error.
-            Term::Cond(box Term::Lit(lit), _, _) => {
-                panic!("Found non-boolean literal {} in condition", lit)
-            }
+            Cond(box Lit(lit), _, _) => panic!("Found non-boolean literal {} in condition", lit),
             // If t1 is not a literal, evaluate it.
-            Term::Cond(ref mut t1, _, _) => (t1.step_in_place(), self),
+            Cond(ref mut t1, _, _) => (t1.step_in_place(), self),
 
             // Fixed-point operation (fix t1)
             // If t1 is an abstraction (\. t2), replace the argument of t1 by (fix t1) inside t2
             // and evaluate to t2.
-            Term::Fix(box Term::Abs(Abstraction::Lambda(box ref t2))) => {
+            Fix(box Abs(Lambda(box ref t2))) => {
                 let mut t2 = t2.clone();
                 t2.replace(0, &mut self);
                 (true, t2)
             }
             // If t1 is not an abstraction, evaluate it.
-            Term::Fix(ref mut t1) => (t1.step_in_place(), self),
+            Fix(ref mut t1) => (t1.step_in_place(), self),
 
             // Any other term stops the evaluation.
-            Term::Var(_) | Term::Lit(_) | Term::Abs(_) | Term::Hole => (false, self),
+            Var(_) | Lit(_) | Abs(_) | Hole => (false, self),
         }
     }
 


### PR DESCRIPTION
This PR introduces two changes:
- Now every evaluation step is done in a non-in-place manner
- Evaluation errors are unrecoverable now.

These two changes affected the benchmarks in the following way
```
arithmetic (master)             time:   [1.2321 us 1.2333 us 1.2347 us]
arithmetic (non-in-place eval)  time:   [3.1190 us 3.1234 us 3.1291 us]
arithmetic (panicking)          time:   [1.5932 us 1.5989 us 1.6086 us]

fact_rec (master)               time:   [434.23 us 434.61 us 435.13 us]
fact_rec (non-in-place eval)    time:   [534.84 us 537.08 us 539.74 us]
fact_rec (panicking)            time:   [1.5932 us 1.5989 us 1.6086 us]

fact_tail (master)              time:   [409.98 us 410.18 us 410.46 us]
fact_tail (non-in-place eval)   time:   [198.70 us 199.69 us 201.28 us]
fact_tail (panicking)           time:   [170.56 us 170.72 us 170.97 us]

fancy_max (master)              time:   [8.6276 us 8.6618 us 8.7115 us]
fancy_max (non-in-place eval)   time:   [3.8642 us 3.8679 us 3.8715 us]
fancy_max (panicking)           time:   [3.4216 us 3.4346 us 3.4495 us]

step (master)                   time:   [3.0806 us 3.0896 us 3.1024 us]
step (non-in-place eval)        time:   [1.9527 us 1.9532 us 1.9539 us]
step (panicking)                time:   [1.4651 us 1.4707 us 1.4798 us]
```
The first change introduced a regression in the `arithmetic` and `fact_rec` benchmarks but improved all the others. Which means the evaluator got slightly worse at crunching long expressions but faster doing conditionals, tail recursion and using higher order functions, which are more common use cases.

After making all errors unrecoverable the evaluator got considerably faster in all benchmarks, almost erasing the regressions introduced before.

Also I think that making evaluation without mutable references makes the code a little bit more readable because it forces all evaluation rules to be written really carefully to not move unnecessary stuff twice. I think this is an improvement in the https://github.com/christianpoveda/pijama/issues/9 direction.