### PR TITLE
Remove Abstraction enum from IRs

### DIFF
--- a/src/lir/ctx.rs
+++ b/src/lir/ctx.rs
@@ -25,18 +25,20 @@ impl<'a> Context<'a> {
                     .unwrap();
                 lir::Term::Var(index)
             }
-            mir::Term::Abs(abs) => {
-                let abs = match abs {
-                    mir::Abstraction::Lambda(bind, body) => {
-                        self.inner.push(bind.name);
-                        let body = self.remove_names(*body);
-                        self.inner.pop().unwrap();
-                        lir::Abstraction::Lambda(Box::new(body))
-                    }
-                    mir::Abstraction::Binary(bin_op) => lir::Abstraction::Binary(bin_op),
-                    mir::Abstraction::Unary(un_op) => lir::Abstraction::Unary(un_op),
-                };
-                lir::Term::Abs(abs)
+            mir::Term::Abs(bind, body) => {
+                self.inner.push(bind.name);
+                let body = self.remove_names(*body);
+                self.inner.pop().unwrap();
+                lir::Term::Abs(Box::new(body))
+            }
+            mir::Term::UnaryOp(op, t1) => {
+                let t1 = self.remove_names(*t1);
+                lir::Term::UnaryOp(op, Box::new(t1))
+            }
+            mir::Term::BinaryOp(op, t1, t2) => {
+                let t1 = self.remove_names(*t1);
+                let t2 = self.remove_names(*t2);
+                lir::Term::BinaryOp(op, Box::new(t1), Box::new(t2))
             }
             mir::Term::App(t1, t2) => {
                 let t1 = self.remove_names(*t1);
@@ -49,7 +51,7 @@ impl<'a> Context<'a> {
                 let t2 = self.remove_names(*t2);
                 self.inner.pop().unwrap();
                 lir::Term::App(
-                    Box::new(lir::Term::Abs(lir::Abstraction::Lambda(Box::new(t2)))),
+                    Box::new(lir::Term::Abs(Box::new(t2))),
                     Box::new(t1),
                 )
             }
@@ -63,7 +65,7 @@ impl<'a> Context<'a> {
                 let t1 = self.remove_names(*t1);
                 let t2 = self.remove_names(*t2);
                 lir::Term::App(
-                    Box::new(lir::Term::Abs(lir::Abstraction::Lambda(Box::new(t2)))),
+                    Box::new(lir::Term::Abs(Box::new(t2))),
                     Box::new(t1),
                 )
             }


### PR DESCRIPTION
This PR removes the `Abstraction` type from the `mir` and `lir` modules and extends the `Term` enum to accommodate binary and unary operations. Now operators don't exist by themselves in the inner representation, i.e., they are saturated.

These changes didn't introduce any benchmark regressions:
```
arithmetic              time:   [919.30 ns 927.84 ns 939.39 ns]                        
                        change: [-45.402% -44.592% -43.654%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  6 (6.00%) high mild
  5 (5.00%) high severe

fact_rec                time:   [215.33 us 216.99 us 219.64 us]                     
                        change: [-26.719% -26.084% -25.382%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) high mild
  8 (8.00%) high severe

fact_tail               time:   [100.80 us 101.08 us 101.42 us]                      
                        change: [-43.156% -42.734% -42.331%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  7 (7.00%) high mild
  5 (5.00%) high severe

fancy_max               time:   [2.5668 us 2.5748 us 2.5831 us]                       
                        change: [-26.381% -25.873% -25.428%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

step                    time:   [1.2365 us 1.2418 us 1.2486 us]                  
                        change: [-15.927% -15.564% -15.063%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe
```