### PR TITLE
Migrate conditional evaluation rule to eval

### DIFF
--- a/src/lir/eval.rs
+++ b/src/lir/eval.rs
@@ -1,0 +1,21 @@
+use super::Term;
+use crate::ast::Literal;
+
+/// Evaluation step for conditionals (if t1 then t2 else t3)
+#[inline(always)]
+pub fn step_conditional(mut t1: Box<Term>, t2: Box<Term>, t3: Box<Term>) -> (bool, Term) {
+    // If t1 is a literal, we should be able to evaluate the conditional
+    if let box Term::Lit(lit) = t1 {
+        match lit {
+            // If t1 is true, evaluate to t2.
+            Literal::Bool(true) => (true, *t2),
+            // If t1 is false, evaluate to t3.
+            Literal::Bool(false) => (true, *t3),
+            // If t1 is any other literal, panic
+            lit => panic!("Found non-boolean literal {} in condition", lit),
+        }
+    // If t1 is not a literal, evaluate it in place and return (if t1 then t2 else t3)
+    } else {
+        (t1.step_in_place(), Term::Cond(t1, t2, t3))
+    }
+}


### PR DESCRIPTION
This PR moves the evaluation rules for conditionals to its own function inside the  `lir/eval` module. Semantically nothing has changed but now the code is a little bit more modular. It seems modularity has a cost, because these changes introduced the following regressions:

```
arithmetic              time:   [935.92 ns 937.14 ns 938.50 ns]                        
                        change: [-0.4826% +0.0029% +0.4497%] (p = 0.99 > 0.05)
                        No change in performance detected.
Found 13 outliers among 100 measurements (13.00%)
  8 (8.00%) high mild
  5 (5.00%) high severe

fact_rec                time:   [218.15 us 219.84 us 222.21 us]                     
                        change: [-0.3688% +0.4753% +1.5109%] (p = 0.32 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) high mild
  8 (8.00%) high severe

fact_tail               time:   [100.61 us 100.84 us 101.15 us]                      
                        change: [+0.3529% +0.9124% +1.4869%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe

fancy_max               time:   [2.6386 us 2.6540 us 2.6767 us]                       
                        change: [+1.0939% +1.6963% +2.3605%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe

step                    time:   [1.2474 us 1.2494 us 1.2515 us]                  
                        change: [+5.0575% +5.9370% +6.6984%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 14 outliers among 100 measurements (14.00%)
  10 (10.00%) high mild
  4 (4.00%) high severe
```

However I'm surprised that this regression only affects benchmarks that do few conditionals in contrast with the recursive `fact_tail` and `fact_rec` benchmarks where a lot of conditionals are used.