### PR TITLE
Replace Literal True False with Bool(bool)

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -66,8 +66,7 @@ impl<'a> fmt::Display for UnOp {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Literal {
-    True,
-    False,
+    Bool(bool),
     Unit,
     Number(i128),
 }
@@ -80,11 +79,7 @@ impl Into<Literal> for i128 {
 
 impl Into<Literal> for bool {
     fn into(self) -> Literal {
-        if self {
-            Literal::True
-        } else {
-            Literal::False
-        }
+        Literal::Bool(self)
     }
 }
 
@@ -92,8 +87,7 @@ impl<'a> fmt::Display for Literal {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use Literal::*;
         match self {
-            True => write!(f, "true"),
-            False => write!(f, "false"),
+            Bool(b) => write!(f, "{}", b),
             Unit => write!(f, "unit"),
             Number(num) => write!(f, "{}", num),
         }

--- a/src/lir.rs
+++ b/src/lir.rs
@@ -156,9 +156,9 @@ impl Term {
 
             // Conditionals (if t1 then t2 else t3)
             // If t1 is true, evaluate to t2.
-            Cond(box Lit(Literal::True), box t2, _) => (true, t2),
+            Cond(box Lit(Literal::Bool(true)), box t2, _) => (true, t2),
             // If t1 is false, evaluate to t3.
-            Cond(box Lit(Literal::False), _, box t3) => (true, t3),
+            Cond(box Lit(Literal::Bool(false)), _, box t3) => (true, t3),
             // If t1 is any other literal, this is an error.
             Cond(box Lit(lit), _, _) => panic!("Found non-boolean literal {} in condition", lit),
             // If t1 is not a literal, evaluate it.
@@ -206,14 +206,8 @@ fn eval_bin_op(op: BinOp, l1: Literal, l2: Literal) -> Literal {
         (GreaterThanOrEqual, Number(n1), Number(n2)) => (n1 >= n2).into(),
         (Equal, l1, l2) => (l1 == l2).into(),
         (NotEqual, l1, l2) => (l1 != l2).into(),
-        (And, True, True) => True,
-        (And, True, False) => False,
-        (And, False, True) => False,
-        (And, False, False) => False,
-        (Or, True, True) => True,
-        (Or, True, False) => True,
-        (Or, False, True) => True,
-        (Or, False, False) => False,
+        (And, Bool(b1), Bool(b2)) => (b1 && b2).into(),
+        (Or, Bool(b1), Bool(b2)) => (b1 || b2).into(),
         (op, l1, l2) => panic!("Unexpected operation `{} {} {}`", l1, op, l2),
     }
 }
@@ -222,9 +216,8 @@ fn eval_un_op(op: UnOp, lit: Literal) -> Literal {
     use Literal::*;
     use UnOp::*;
     match (op, lit) {
-        (Minus, Number(n)) => Number(-n),
-        (Not, True) => False,
-        (Not, False) => True,
+        (Minus, Number(n)) => (-n).into(),
+        (Not, Bool(b)) => (!b).into(),
         (op, lit) => panic!("Unexpected operation `{} {}`", op, lit),
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -106,8 +106,8 @@ impl<'a> UnOp {
 impl<'a> Literal {
     fn parse<E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Self, E> {
         alt((
-            map(tag("true"), |_| Self::True),
-            map(tag("false"), |_| Self::False),
+            map(tag("true"), |_| Self::Bool(true)),
+            map(tag("false"), |_| Self::Bool(false)),
             map(tag("unit"), |_| Self::Unit),
             map(
                 tuple((opt(char('-')), digit1)),

--- a/src/ty/ty_check.rs
+++ b/src/ty/ty_check.rs
@@ -33,7 +33,7 @@ impl<'a> Context<'a> {
         let ty = match term {
             Term::Lit(lit) => match lit {
                 Literal::Unit => Ty::Unit,
-                Literal::True | Literal::False => Ty::Bool,
+                Literal::Bool(_) => Ty::Bool,
                 Literal::Number(_) => Ty::Int,
             },
             Term::Var(name) => self

--- a/tests/parse/mod.rs
+++ b/tests/parse/mod.rs
@@ -29,8 +29,8 @@ fn literal() -> LangResult<()> {
         Literal(ast::Literal::Number(0)),
         Literal(ast::Literal::Number(-1)),
         Literal(ast::Literal::Number(14142)),
-        Literal(ast::Literal::True),
-        Literal(ast::Literal::False),
+        Literal(ast::Literal::Bool(true)),
+        Literal(ast::Literal::Bool(false)),
         Literal(ast::Literal::Unit),
     ];
 


### PR DESCRIPTION
Implements #13 

Local benchmark shows 'just' noise and a small regression in arithmetic and fact_tail.
```
arithmetic              time:   [967.86 ns 968.97 ns 970.15 ns]                        
                        change: [+1.5771% +3.0780% +4.3723%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe

fact_rec                time:   [240.78 us 241.05 us 241.38 us]                     
                        change: [-0.7449% +0.3168% +1.2462%] (p = 0.55 > 0.05)
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe

fact_tail               time:   [113.93 us 114.46 us 115.14 us]                      
                        change: [+2.0108% +2.4331% +2.8414%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) high mild
  7 (7.00%) high severe

fancy_max               time:   [3.9728 us 3.9773 us 3.9818 us]                       
                        change: [+0.6262% +0.9487% +1.2290%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe

step                    time:   [1.5238 us 1.5254 us 1.5271 us]                  
                        change: [-0.2574% +0.0432% +0.3701%] (p = 0.79 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe
```
