### PR TITLE
Migrate beta reduction rule to eval

### DIFF
--- a/src/lir.rs
+++ b/src/lir.rs
@@ -136,14 +136,8 @@ impl Term {
             // If t1 is not a literal, evaluate it.
             BinaryOp(_, ref mut t1, _) => (t1.step_in_place(), self),
 
-            // Beta Reduction ((\. b) t2)
-            // Replace the argument of the function by t2 inside b and evaluate to b.
-            App(box Abs(box mut body), box mut t2) => {
-                t2.shift(true, 0);
-                body.replace(0, &mut t2);
-                body.shift(false, 0);
-                (true, body)
-            }
+            // Dispatch step for beta reduction
+            App(box Abs(body), arg) => step_beta_reduction(body, arg),
 
             // Unary Operations (op t1)
             // If t1 is a literal, do the operation.

--- a/src/lir/eval.rs
+++ b/src/lir/eval.rs
@@ -19,3 +19,17 @@ pub fn step_conditional(mut t1: Box<Term>, t2: Box<Term>, t3: Box<Term>) -> (boo
         (t1.step_in_place(), Term::Cond(t1, t2, t3))
     }
 }
+
+/// Evaluation step for beta reduction ((λ. body) arg)
+#[inline(always)]
+pub fn step_beta_reduction(mut body: Box<Term>, mut arg: Box<Term>) -> (bool, Term) {
+    // increase the indices of the argument so they can coincide with the indices of the body.
+    arg.shift(true, 0);
+    // replace the index 0 by the argument inside the body.
+    body.replace(0, &mut arg);
+    // decrease the indices of the body to take into account the fact that the abstraction no
+    // longer exists.
+    body.shift(false, 0);
+    // return the body
+    (true, *body)
+}


### PR DESCRIPTION
Another step towards https://github.com/christianpoveda/pijama/issues/9. 

Apparently moving boxed terms improved the benchmark performance (`arithmethic` wasn't affected because it doesn't use functions at all): 

```
arithmetic              time:   [1.0138 us 1.0231 us 1.0350 us]                        
                        change: [-6.3454% -3.4521% -0.7574%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 16 outliers among 100 measurements (16.00%)
  4 (4.00%) low mild
  2 (2.00%) high mild
  10 (10.00%) high severe

fact_rec                time:   [231.13 us 231.96 us 232.98 us]                     
                        change: [-5.4684% -3.7797% -2.2206%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  1 (1.00%) low severe
  3 (3.00%) low mild
  4 (4.00%) high mild
  5 (5.00%) high severe

fact_tail               time:   [106.17 us 106.80 us 107.66 us]                      
                        change: [-15.023% -10.721% -6.3776%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  4 (4.00%) low mild
  2 (2.00%) high mild
  9 (9.00%) high severe

fancy_max               time:   [2.8009 us 2.8088 us 2.8178 us]                       
                        change: [-6.7545% -5.2914% -3.9390%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 18 outliers among 100 measurements (18.00%)
  1 (1.00%) low severe
  6 (6.00%) low mild
  8 (8.00%) high mild
  3 (3.00%) high severe

step                    time:   [1.2692 us 1.2719 us 1.2748 us]                  
                        change: [-10.832% -8.5507% -6.5852%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  2 (2.00%) low severe
  3 (3.00%) low mild
  3 (3.00%) high mild
  5 (5.00%) high severe
```