### PR TITLE
Add type check error as panic message

### DIFF
--- a/tests/type_check/error/mod.rs
+++ b/tests/type_check/error/mod.rs
@@ -8,125 +8,162 @@ use pijama::LangError;
 fn wrong_cond_input_mismatch() {
     let input = include_str!("wrong_cond_input_mismatch.pj");
     let error = type_check(input);
-    assert!(matches!(
-        error,
-        Result::Err(LangError::Ty(TyError::Mismatch {
-            expected: Ty::Bool,
-            found: Ty::Int
-        }))
-    ));
+    assert!(
+        matches!(
+            error,
+            Result::Err(LangError::Ty(TyError::Mismatch {
+                expected: Ty::Bool,
+                found: Ty::Int
+            }))
+        ),
+        "{:#?}",
+        error
+    );
 }
 
 #[test]
 fn wrong_cond_result_mismatch() {
     let input = include_str!("wrong_cond_result_mismatch.pj");
     let error = type_check(input);
-    assert!(matches!(
-        error,
-        Result::Err(LangError::Ty(TyError::Mismatch {
-            expected: Ty::Bool,
-            found: Ty::Int
-        }))
-    ));
+    assert!(
+        matches!(
+            error,
+            Result::Err(LangError::Ty(TyError::Mismatch {
+                expected: Ty::Bool,
+                found: Ty::Int
+            }))
+        ),
+        "{:#?}",
+        error
+    );
 }
 
 #[test]
 fn unary_minus_mismatch() {
     let input = include_str!("unary_minus_mismatch.pj");
     let error = type_check(input);
-    assert!(matches!(
-        error,
-        Result::Err(LangError::Ty(TyError::Mismatch {
-            expected: Ty::Int,
-            found: Ty::Bool
-        }))
-    ));
+    assert!(
+        matches!(
+            error,
+            Result::Err(LangError::Ty(TyError::Mismatch {
+                expected: Ty::Int,
+                found: Ty::Bool
+            }))
+        ),
+        "{:#?}",
+        error
+    );
 }
 
 #[test]
 fn not_mismatch() {
     let input = include_str!("not_mismatch.pj");
     let error = type_check(input);
-    assert!(matches!(
-        error,
-        Result::Err(LangError::Ty(TyError::Mismatch {
-            expected: Ty::Bool,
-            found: Ty::Int
-        }))
-    ));
+    assert!(
+        matches!(
+            error,
+            Result::Err(LangError::Ty(TyError::Mismatch {
+                expected: Ty::Bool,
+                found: Ty::Int
+            }))
+        ),
+        "{:#?}",
+        error
+    );
 }
 
 #[test]
 fn mixed_type_binop_mismatch() {
     let input = include_str!("mixed_type_binop_mismatch.pj");
     let error = type_check(input);
-    assert!(matches!(
-        error,
-        Result::Err(LangError::Ty(TyError::Mismatch {
-            expected: Ty::Int,
-            found: Ty::Bool
-        }))
-    ));
+    assert!(
+        matches!(
+            error,
+            Result::Err(LangError::Ty(TyError::Mismatch {
+                expected: Ty::Int,
+                found: Ty::Bool
+            }))
+        ),
+        "{:#?}",
+        error
+    );
 }
 
 #[test]
 fn wrong_type_int_binop_mismatch() {
     let input = include_str!("wrong_type_int_binop_mismatch.pj");
     let error = type_check(input);
-    assert!(matches!(
-        error,
-        Result::Err(LangError::Ty(TyError::Mismatch {
-            expected: Ty::Int,
-            found: Ty::Bool
-        }))
-    ));
+    assert!(
+        matches!(
+            error,
+            Result::Err(LangError::Ty(TyError::Mismatch {
+                expected: Ty::Int,
+                found: Ty::Bool
+            }))
+        ),
+        "{:#?}",
+        error
+    );
 }
 
 #[test]
 fn wrong_type_bool_binop_mismatch() {
     let input = include_str!("wrong_type_bool_binop_mismatch.pj");
     let error = type_check(input);
-    assert!(matches!(
-        error,
-        Result::Err(LangError::Ty(TyError::Mismatch {
-            expected: Ty::Bool,
-            found: Ty::Int
-        }))
-    ));
+    assert!(
+        matches!(
+            error,
+            Result::Err(LangError::Ty(TyError::Mismatch {
+                expected: Ty::Bool,
+                found: Ty::Int
+            }))
+        ),
+        "{:#?}",
+        error
+    );
 }
 
 #[test]
 fn wrong_type_cmp_mismatch() {
     let input = include_str!("wrong_type_cmp_mismatch.pj");
     let error = type_check(input);
-    assert!(matches!(
-        error,
-        Result::Err(LangError::Ty(TyError::Mismatch {
-            expected: Ty::Int,
-            found: Ty::Bool
-        }))
-    ));
+    assert!(
+        matches!(
+            error,
+            Result::Err(LangError::Ty(TyError::Mismatch {
+                expected: Ty::Int,
+                found: Ty::Bool
+            }))
+        ),
+        "{:#?}",
+        error
+    );
 }
 
 #[test]
 fn fn_arg_mismatch() {
     let input = include_str!("fn_arg_mismatch.pj");
     let error = type_check(input);
-    assert!(matches!(
-        error,
-        Result::Err(LangError::Ty(TyError::Mismatch {
-            expected: Ty::Int,
-            found: Ty::Bool
-        }))
-    ));
+    assert!(
+        matches!(
+            error,
+            Result::Err(LangError::Ty(TyError::Mismatch {
+                expected: Ty::Int,
+                found: Ty::Bool
+            }))
+        ),
+        "{:#?}",
+        error
+    );
 }
 
 #[test]
 fn var_unbounded() {
     let input = include_str!("var_unbounded.pj");
     let error = type_check(input);
-    assert!(matches!(
-        error,
-        Result::Err(LangError::Ty(TyError::Unbound(_)))
-    ));
+    assert!(
+        matches!(error, Result::Err(LangError::Ty(TyError::Unbound(_)))),
+        "{:#?}",
+        error
+    );
 }


### PR DESCRIPTION
Since assert!(matches!()) does not have a nice inbuilt error reporting we can at least manually print the actual error as panic message.
I have decided against additional text in the panic message like "Wrong error got..." to keep the printed error as clean as possible but it is possible to add one.

After
```
Err(
    Ty(
        Mismatch {
            expected: Bool,
            found: Int,
        },
    ),
)
thread 'type_check::error::wrong_cond_input_mismatch' panicked at 'Err(
    Ty(
        Mismatch {
            expected: Bool,
            found: Int,
        },
    ),
)', tests/type_check/error/mod.rs:11:5
```

Before
```
assertion failed: matches!(error, Result ::
         Err(LangError ::
             Ty(TyError :: Mismatch
                { expected : Ty :: Bool, found : Ty :: Bool })))
thread 'type_check::error::wrong_cond_input_mismatch' panicked at 'assertion failed: matches!(error, Result ::
         Err(LangError ::
             Ty(TyError :: Mismatch
                { expected : Ty :: Bool, found : Ty :: Bool })))', tests/type_check/error/mod.rs:11:5
```