### PR TITLE
Shorten bin ops

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -60,7 +60,7 @@ impl<'a> fmt::Display for BinOp {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum UnOp {
-    Sub,
+    Neg,
     Not,
 }
 
@@ -69,7 +69,7 @@ impl<'a> fmt::Display for UnOp {
         use UnOp::*;
         match self {
             Not => write!(f, "!"),
-            Sub => write!(f, "-"),
+            Neg => write!(f, "-"),
         }
     }
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -39,7 +39,7 @@ impl<'a> fmt::Display for BinOp {
             Add => write!(f, "+"),
             Sub => write!(f, "-"),
             Mul => write!(f, "*"),
-            Div=> write!(f, "/"),
+            Div => write!(f, "/"),
             Rem => write!(f, "%"),
             And => write!(f, "&&"),
             Or => write!(f, "||"),

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -12,11 +12,11 @@ impl<'a> fmt::Display for Name<'a> {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum BinOp {
-    Plus,
-    Minus,
-    Times,
-    Divide,
-    Modulo,
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Rem,
     And,
     Or,
     BitAnd,
@@ -24,23 +24,23 @@ pub enum BinOp {
     BitXor,
     Shr,
     Shl,
-    Equal,
-    NotEqual,
-    LessThan,
-    GreaterThan,
-    LessThanOrEqual,
-    GreaterThanOrEqual,
+    Eq,
+    Neq,
+    Lt,
+    Gt,
+    Lte,
+    Gte,
 }
 
 impl<'a> fmt::Display for BinOp {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use BinOp::*;
         match self {
-            Plus => write!(f, "+"),
-            Minus => write!(f, "-"),
-            Times => write!(f, "*"),
-            Divide => write!(f, "/"),
-            Modulo => write!(f, "%"),
+            Add => write!(f, "+"),
+            Sub => write!(f, "-"),
+            Mul => write!(f, "*"),
+            Div=> write!(f, "/"),
+            Rem => write!(f, "%"),
             And => write!(f, "&&"),
             Or => write!(f, "||"),
             BitAnd => write!(f, "&"),
@@ -48,19 +48,19 @@ impl<'a> fmt::Display for BinOp {
             BitXor => write!(f, "^"),
             Shr => write!(f, ">>"),
             Shl => write!(f, "<<"),
-            Equal => write!(f, "=="),
-            NotEqual => write!(f, "!="),
-            LessThan => write!(f, "<"),
-            GreaterThan => write!(f, ">"),
-            LessThanOrEqual => write!(f, "<="),
-            GreaterThanOrEqual => write!(f, ">="),
+            Eq => write!(f, "=="),
+            Neq => write!(f, "!="),
+            Lt => write!(f, "<"),
+            Gt => write!(f, ">"),
+            Lte => write!(f, "<="),
+            Gte => write!(f, ">="),
         }
     }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum UnOp {
-    Minus,
+    Sub,
     Not,
 }
 
@@ -69,7 +69,7 @@ impl<'a> fmt::Display for UnOp {
         use UnOp::*;
         match self {
             Not => write!(f, "!"),
-            Minus => write!(f, "-"),
+            Sub => write!(f, "-"),
         }
     }
 }

--- a/src/lir/eval.rs
+++ b/src/lir/eval.rs
@@ -85,17 +85,17 @@ fn native_bin_op(op: BinOp, l1: Literal, l2: Literal) -> Literal {
     use Literal::*;
 
     match (op, l1, l2) {
-        (Plus, Number(n1), Number(n2)) => (n1 + n2).into(),
-        (Minus, Number(n1), Number(n2)) => (n1 - n2).into(),
-        (Times, Number(n1), Number(n2)) => (n1 * n2).into(),
-        (Divide, Number(n1), Number(n2)) => (n1 / n2).into(),
-        (Modulo, Number(n1), Number(n2)) => (n1 % n2).into(),
-        (LessThan, Number(n1), Number(n2)) => (n1 < n2).into(),
-        (LessThanOrEqual, Number(n1), Number(n2)) => (n1 <= n2).into(),
-        (GreaterThan, Number(n1), Number(n2)) => (n1 > n2).into(),
-        (GreaterThanOrEqual, Number(n1), Number(n2)) => (n1 >= n2).into(),
-        (Equal, l1, l2) => (l1 == l2).into(),
-        (NotEqual, l1, l2) => (l1 != l2).into(),
+        (Add, Number(n1), Number(n2)) => (n1 + n2).into(),
+        (Sub, Number(n1), Number(n2)) => (n1 - n2).into(),
+        (Mul, Number(n1), Number(n2)) => (n1 * n2).into(),
+        (Div, Number(n1), Number(n2)) => (n1 / n2).into(),
+        (Rem, Number(n1), Number(n2)) => (n1 % n2).into(),
+        (Lt, Number(n1), Number(n2)) => (n1 < n2).into(),
+        (Lte, Number(n1), Number(n2)) => (n1 <= n2).into(),
+        (Gt, Number(n1), Number(n2)) => (n1 > n2).into(),
+        (Gte, Number(n1), Number(n2)) => (n1 >= n2).into(),
+        (Eq, l1, l2) => (l1 == l2).into(),
+        (Neq, l1, l2) => (l1 != l2).into(),
         (And, Bool(b1), Bool(b2)) => (b1 && b2).into(),
         (Or, Bool(b1), Bool(b2)) => (b1 || b2).into(),
         (BitAnd, Number(n1), Number(n2)) => (n1 & n2).into(),
@@ -112,7 +112,7 @@ fn native_un_op(op: UnOp, lit: Literal) -> Literal {
     use UnOp::*;
 
     match (op, lit) {
-        (Minus, Number(n)) => (-n).into(),
+        (Sub, Number(n)) => (-n).into(),
         (Not, Bool(b)) => (!b).into(),
         (op, lit) => panic!("Unexpected operation `{} {}`", op, lit),
     }

--- a/src/lir/eval.rs
+++ b/src/lir/eval.rs
@@ -112,7 +112,7 @@ fn native_un_op(op: UnOp, lit: Literal) -> Literal {
     use UnOp::*;
 
     match (op, lit) {
-        (Sub, Number(n)) => (-n).into(),
+        (Neg, Number(n)) => (-n).into(),
         (Not, Bool(b)) => (!b).into(),
         (op, lit) => panic!("Unexpected operation `{} {}`", op, lit),
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -79,7 +79,7 @@ fn name<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Name<'a>
 fn un_op<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, UnOp, E> {
     alt((
         map(char('!'), |_| UnOp::Not),
-        map(char('-'), |_| UnOp::Minus),
+        map(char('-'), |_| UnOp::Sub),
     ))(input)
 }
 
@@ -135,12 +135,12 @@ fn node_1<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Node, 
 fn bin_op_2<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, BinOp, E> {
     use BinOp::*;
     alt((
-        map(tag("<="), |_| LessThanOrEqual),
-        map(tag(">="), |_| GreaterThanOrEqual),
-        map(terminated(char('<'), peek(not(char('<')))), |_| LessThan),
-        map(terminated(char('>'), peek(not(char('>')))), |_| GreaterThan),
-        map(tag("=="), |_| Equal),
-        map(tag("!="), |_| NotEqual),
+        map(tag("<="), |_| Lte),
+        map(tag(">="), |_| Gte),
+        map(terminated(char('<'), peek(not(char('<')))), |_| Lt),
+        map(terminated(char('>'), peek(not(char('>')))), |_| Gt),
+        map(tag("=="), |_| Eq),
+        map(tag("!="), |_| Neq),
     ))(input)
 }
 
@@ -190,7 +190,7 @@ fn node_4<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Node, 
 
 fn bin_op_4<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, BinOp, E> {
     use BinOp::*;
-    alt((map(char('+'), |_| Plus), map(char('-'), |_| Minus)))(input)
+    alt((map(char('+'), |_| Add), map(char('-'), |_| Sub)))(input)
 }
 
 fn node_5<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Node, E> {
@@ -211,9 +211,9 @@ fn node_5<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Node, 
 fn bin_op_5<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, BinOp, E> {
     use BinOp::*;
     alt((
-        map(char('*'), |_| Times),
-        map(char('/'), |_| Divide),
-        map(char('%'), |_| Modulo),
+        map(char('*'), |_| Mul),
+        map(char('/'), |_| Div),
+        map(char('%'), |_| Rem),
     ))(input)
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -77,10 +77,7 @@ fn name<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Name<'a>
 }
 
 fn un_op<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, UnOp, E> {
-    alt((
-        map(char('!'), |_| UnOp::Not),
-        map(char('-'), |_| UnOp::Neg),
-    ))(input)
+    alt((map(char('!'), |_| UnOp::Not), map(char('-'), |_| UnOp::Neg)))(input)
 }
 
 fn literal<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Literal, E> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -79,7 +79,7 @@ fn name<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Name<'a>
 fn un_op<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, UnOp, E> {
     alt((
         map(char('!'), |_| UnOp::Not),
-        map(char('-'), |_| UnOp::Sub),
+        map(char('-'), |_| UnOp::Neg),
     ))(input)
 }
 

--- a/src/ty/ty_check.rs
+++ b/src/ty/ty_check.rs
@@ -59,7 +59,7 @@ impl<'a> Context<'a> {
             Term::UnaryOp(op, term) => {
                 let ty = self.type_of(term)?;
                 match op {
-                    UnOp::Sub => expect_ty(Ty::Int, ty)?,
+                    UnOp::Neg => expect_ty(Ty::Int, ty)?,
                     UnOp::Not => expect_ty(Ty::Bool, ty)?,
                 }
             }

--- a/src/ty/ty_check.rs
+++ b/src/ty/ty_check.rs
@@ -79,10 +79,7 @@ impl<'a> Context<'a> {
                     | BinOp::Shr
                     | BinOp::Shl => expect_ty(Ty::Int, ty)?,
                     BinOp::Or | BinOp::And => expect_ty(Ty::Bool, ty)?,
-                    BinOp::Lt
-                    | BinOp::Gt
-                    | BinOp::Lte
-                    | BinOp::Gte => {
+                    BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte => {
                         expect_ty(Ty::Int, ty)?;
                         Ty::Bool
                     }

--- a/src/ty/ty_check.rs
+++ b/src/ty/ty_check.rs
@@ -59,7 +59,7 @@ impl<'a> Context<'a> {
             Term::UnaryOp(op, term) => {
                 let ty = self.type_of(term)?;
                 match op {
-                    UnOp::Minus => expect_ty(Ty::Int, ty)?,
+                    UnOp::Sub => expect_ty(Ty::Int, ty)?,
                     UnOp::Not => expect_ty(Ty::Bool, ty)?,
                 }
             }
@@ -68,25 +68,25 @@ impl<'a> Context<'a> {
                 let ty2 = self.type_of(t2)?;
                 let ty = expect_ty(ty1, ty2)?;
                 match op {
-                    BinOp::Plus
-                    | BinOp::Minus
-                    | BinOp::Times
-                    | BinOp::Divide
-                    | BinOp::Modulo
+                    BinOp::Add
+                    | BinOp::Sub
+                    | BinOp::Mul
+                    | BinOp::Div
+                    | BinOp::Rem
                     | BinOp::BitAnd
                     | BinOp::BitOr
                     | BinOp::BitXor
                     | BinOp::Shr
                     | BinOp::Shl => expect_ty(Ty::Int, ty)?,
                     BinOp::Or | BinOp::And => expect_ty(Ty::Bool, ty)?,
-                    BinOp::LessThan
-                    | BinOp::GreaterThan
-                    | BinOp::LessThanOrEqual
-                    | BinOp::GreaterThanOrEqual => {
+                    BinOp::Lt
+                    | BinOp::Gt
+                    | BinOp::Lte
+                    | BinOp::Gte => {
                         expect_ty(Ty::Int, ty)?;
                         Ty::Bool
                     }
-                    BinOp::Equal | BinOp::NotEqual => Ty::Bool,
+                    BinOp::Eq | BinOp::Neq => Ty::Bool,
                 }
             }
             Term::App(t1, t2) => {

--- a/tests/parse/mod.rs
+++ b/tests/parse/mod.rs
@@ -48,16 +48,16 @@ fn binary_op() -> LangResult<()> {
     let input = include_str!("bin_op.pj");
     let result = parse(input)?;
     let expected = vec![
-        BinaryOp(Plus, box Name(ast::Name("a")), box Name(ast::Name("b"))),
+        BinaryOp(Add, box Name(ast::Name("a")), box Name(ast::Name("b"))),
         BinaryOp(
-            Plus,
-            box BinaryOp(Plus, box Name(ast::Name("a")), box Name(ast::Name("b"))),
+            Add,
+            box BinaryOp(Add, box Name(ast::Name("a")), box Name(ast::Name("b"))),
             box Name(ast::Name("c")),
         ),
         BinaryOp(
-            Plus,
+            Add,
             box Name(ast::Name("a")),
-            box BinaryOp(Plus, box Name(ast::Name("b")), box Name(ast::Name("c"))),
+            box BinaryOp(Add, box Name(ast::Name("b")), box Name(ast::Name("c"))),
         ),
     ];
 
@@ -72,7 +72,7 @@ fn unary_op() -> LangResult<()> {
     let input = include_str!("un_op.pj");
     let result = parse(input)?;
     let expected = vec![
-        UnaryOp(UnOp::Minus, box Name(ast::Name("x"))),
+        UnaryOp(UnOp::Sub, box Name(ast::Name("x"))),
         UnaryOp(UnOp::Not, box Name(ast::Name("x"))),
         UnaryOp(UnOp::Not, box UnaryOp(UnOp::Not, box Name(ast::Name("x")))),
         UnaryOp(UnOp::Not, box Name(ast::Name("x"))),
@@ -150,7 +150,7 @@ fn let_bind() -> LangResult<()> {
         LetBind(
             ast::Name("x"),
             None,
-            box BinaryOp(Plus, box Name(ast::Name("y")), box Name(ast::Name("z"))),
+            box BinaryOp(Add, box Name(ast::Name("y")), box Name(ast::Name("z"))),
         ),
         LetBind(ast::Name("x"), Some(Ty::Int), box Name(ast::Name("y"))),
     ];
@@ -253,24 +253,24 @@ fn precedence() -> LangResult<()> {
     let result = parse(input)?;
     let expected = vec![
         BinaryOp(
-            Plus,
+            Add,
             box Name(ast::Name("a")),
-            box BinaryOp(Times, box Name(ast::Name("b")), box Name(ast::Name("c"))),
+            box BinaryOp(Mul, box Name(ast::Name("b")), box Name(ast::Name("c"))),
         ),
         BinaryOp(
             BitAnd,
             box Name(ast::Name("a")),
-            box BinaryOp(Plus, box Name(ast::Name("b")), box Name(ast::Name("c"))),
+            box BinaryOp(Add, box Name(ast::Name("b")), box Name(ast::Name("c"))),
         ),
         BinaryOp(
-            Equal,
+            Eq,
             box Name(ast::Name("a")),
             box BinaryOp(BitAnd, box Name(ast::Name("b")), box Name(ast::Name("c"))),
         ),
         BinaryOp(
             And,
             box Name(ast::Name("a")),
-            box BinaryOp(Equal, box Name(ast::Name("b")), box Name(ast::Name("c"))),
+            box BinaryOp(Eq, box Name(ast::Name("b")), box Name(ast::Name("c"))),
         ),
     ];
     assert_eq!(expected[0], result[0], "mul precedes add");
@@ -286,12 +286,12 @@ fn cmp_and_shift() -> LangResult<()> {
     let result = parse(input)?;
     let expected = vec![
         BinaryOp(
-            LessThan,
+            Lt,
             box BinaryOp(Shl, box Name(ast::Name("a")), box Name(ast::Name("b"))),
             box BinaryOp(Shl, box Name(ast::Name("c")), box Name(ast::Name("d"))),
         ),
         BinaryOp(
-            GreaterThan,
+            Gt,
             box BinaryOp(Shr, box Name(ast::Name("a")), box Name(ast::Name("b"))),
             box BinaryOp(Shr, box Name(ast::Name("c")), box Name(ast::Name("d"))),
         ),
@@ -301,7 +301,7 @@ fn cmp_and_shift() -> LangResult<()> {
                 Shr,
                 box Name(ast::Name("a")),
                 box BinaryOp(
-                    GreaterThan,
+                    Gt,
                     box Name(ast::Name("b")),
                     box Name(ast::Name("c")),
                 ),

--- a/tests/parse/mod.rs
+++ b/tests/parse/mod.rs
@@ -72,7 +72,7 @@ fn unary_op() -> LangResult<()> {
     let input = include_str!("un_op.pj");
     let result = parse(input)?;
     let expected = vec![
-        UnaryOp(UnOp::Sub, box Name(ast::Name("x"))),
+        UnaryOp(UnOp::Neg, box Name(ast::Name("x"))),
         UnaryOp(UnOp::Not, box Name(ast::Name("x"))),
         UnaryOp(UnOp::Not, box UnaryOp(UnOp::Not, box Name(ast::Name("x")))),
         UnaryOp(UnOp::Not, box Name(ast::Name("x"))),

--- a/tests/parse/mod.rs
+++ b/tests/parse/mod.rs
@@ -300,11 +300,7 @@ fn cmp_and_shift() -> LangResult<()> {
             box BinaryOp(
                 Shr,
                 box Name(ast::Name("a")),
-                box BinaryOp(
-                    Gt,
-                    box Name(ast::Name("b")),
-                    box Name(ast::Name("c")),
-                ),
+                box BinaryOp(Gt, box Name(ast::Name("b")), box Name(ast::Name("c"))),
             ),
             box Name(ast::Name("d")),
         ),


### PR DESCRIPTION
Addresses #26 

I also went ahead and shortened `UnOp::Minus` to `UnOp::Sub` to match `BinOp::Sub`.