### PR TITLE
Add support for anonymous functions

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -112,7 +112,7 @@ pub enum Node<'a> {
     UnaryOp(UnOp, Box<Node<'a>>),
     LetBind(Name<'a>, Option<Ty>, Box<Node<'a>>),
     Cond(Block<'a>, Block<'a>, Block<'a>),
-    FnDef(Name<'a>, Vec<Binding<'a>>, Block<'a>, Option<Ty>),
+    FnDef(Option<Name<'a>>, Vec<Binding<'a>>, Block<'a>, Option<Ty>),
     FnRecDef(Name<'a>, Vec<Binding<'a>>, Block<'a>, Ty),
     Call(Name<'a>, Block<'a>),
     Literal(Literal),

--- a/src/mir.rs
+++ b/src/mir.rs
@@ -69,7 +69,7 @@ fn lower_node(node: Node<'_>) -> TyResult<Term<'_>> {
         Node::BinaryOp(bin_op, node1, node2) => lower_binary_op(bin_op, *node1, *node2),
         Node::UnaryOp(un_op, node) => lower_unary_op(un_op, *node),
         Node::LetBind(name, opt_ty, node) => lower_let_bind(name, opt_ty, *node),
-        Node::FnDef(name, binds, body, opt_ty) => lower_fn_def(name, binds, body, opt_ty),
+        Node::FnDef(opt_name, binds, body, opt_ty) => lower_fn_def(opt_name, binds, body, opt_ty),
         Node::FnRecDef(name, binds, body, ty) => lower_fn_rec_def(name, binds, body, ty),
     }
 }
@@ -118,7 +118,7 @@ fn lower_let_bind<'a>(name: Name<'a>, opt_ty: Option<Ty>, node: Node<'a>) -> TyR
 }
 
 fn lower_fn_def<'a>(
-    name: Name<'a>,
+    opt_name: Option<Name<'a>>,
     binds: Vec<Binding<'a>>,
     body: Block<'a>,
     opt_ty: Option<Ty>,
@@ -141,11 +141,11 @@ fn lower_fn_def<'a>(
         expect_ty(ty, term_ty)?;
     }
 
-    Ok(Term::Let(
-        name,
-        Box::new(term),
-        Box::new(Term::Lit(Literal::Unit)),
-    ))
+    if let Some(name) = opt_name {
+        term = Term::Let(name, Box::new(term), Box::new(Term::Lit(Literal::Unit)));
+    }
+
+    Ok(term)
 }
 
 fn lower_fn_rec_def<'a>(

--- a/src/parser/node/fn_def.rs
+++ b/src/parser/node/fn_def.rs
@@ -4,10 +4,11 @@
 //! rule
 //!
 //! ```abnf
-//! fn_def = "fn" name "(" (binding ("," binding)*)? ")" (":" ty)? "do" block1 "end"
+//! fn_def = "fn" name? "(" (binding ("," binding)*)? ")" (":" ty)? "do" block1 "end"
 //! ```
 //!
-//! Meaning that the return type binding is optional.
+//! Meaning that the return type binding and name are optional. If the name is not given, the
+//! expression will be interpreted as an anonymous function.
 //!
 //! The [`fn_body`] and [`args`] parsers are reutilized in the [`fn_rec_def`] and [`call`] parsers.
 //!
@@ -50,11 +51,12 @@ pub fn fn_def<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, No
     )(input)
 }
 
-/// Parses the name of a function in a definition.
+/// Parses the name of a function in a definition if it has one.
 ///
-/// This parser requires that the name is preceded by `"fn"` and at least one space.
-fn fn_name<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Name, E> {
-    preceded(pair(tag("fn"), space1), name)(input)
+/// This parser requires that the name is preceded by `"fn"` and at least one space. If the
+/// function does not have a name, it need to parse the `"fn"` only.
+fn fn_name<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Option<Name>, E> {
+    preceded(tag("fn"), opt(preceded(space1, name)))(input)
 }
 
 /// Parser for arguments of a function definition or function call.

--- a/tests/eval/fancy_max.pj
+++ b/tests/eval/fancy_max.pj
@@ -6,8 +6,9 @@ fn fancy_max(gt: Int -> Int -> Bool, x: Int, y: Int) do
     end
 end
 
-fn regular_gt(x: Int, y: Int) do
-    (x - y) > 0
-end
 
-fancy_max(regular_gt, 10, -10)
+fancy_max(
+    fn(x: Int, y: Int) do (x - y) > 0 end,
+    10,
+    -10
+)

--- a/tests/parse/fn_def.pj
+++ b/tests/parse/fn_def.pj
@@ -5,3 +5,5 @@ fn foo(x: Int, y: Int) do
  x
  y
 end
+fn(x: Int) do x end
+fn (x: Int) do x end

--- a/tests/parse/let_bind.pj
+++ b/tests/parse/let_bind.pj
@@ -1,3 +1,4 @@
 x = y
 x = y + z
 x: Int = y
+foo = fn(x: Int) do x end

--- a/tests/parse/mod.rs
+++ b/tests/parse/mod.rs
@@ -153,11 +153,25 @@ fn let_bind() -> LangResult<()> {
             box BinaryOp(Add, box Name(ast::Name("y")), box Name(ast::Name("z"))),
         ),
         LetBind(ast::Name("x"), Some(Ty::Int), box Name(ast::Name("y"))),
+        LetBind(
+            ast::Name("foo"),
+            None,
+            box FnDef(
+                None,
+                vec![Binding {
+                    name: ast::Name("x"),
+                    ty: Ty::Int,
+                }],
+                vec![Name(ast::Name("x"))],
+                None,
+            ),
+        ),
     ];
 
     assert_eq!(expected[0], result[0], "simple");
     assert_eq!(expected[1], result[1], "bind to bin op");
     assert_eq!(expected[2], result[2], "type binding");
+    assert_eq!(expected[3], result[3], "bind to nameless function");
     Ok(())
 }
 
@@ -207,9 +221,9 @@ fn fn_def() -> LangResult<()> {
     let input = include_str!("fn_def.pj");
     let result = parse(input)?;
     let expected = vec![
-        FnDef(ast::Name("foo"), vec![], vec![], None),
+        FnDef(Some(ast::Name("foo")), vec![], vec![], None),
         FnDef(
-            ast::Name("foo"),
+            Some(ast::Name("foo")),
             vec![Binding {
                 name: ast::Name("x"),
                 ty: Ty::Int,
@@ -224,7 +238,7 @@ fn fn_def() -> LangResult<()> {
             Ty::Unit,
         ),
         FnDef(
-            ast::Name("foo"),
+            Some(ast::Name("foo")),
             vec![
                 Binding {
                     name: ast::Name("x"),
@@ -238,12 +252,32 @@ fn fn_def() -> LangResult<()> {
             vec![Name(ast::Name("x")), Name(ast::Name("y"))],
             None,
         ),
+        FnDef(
+            None,
+            vec![Binding {
+                name: ast::Name("x"),
+                ty: Ty::Int,
+            }],
+            vec![Name(ast::Name("x"))],
+            None,
+        ),
+        FnDef(
+            None,
+            vec![Binding {
+                name: ast::Name("x"),
+                ty: Ty::Int,
+            }],
+            vec![Name(ast::Name("x"))],
+            None,
+        ),
     ];
 
     assert_eq!(expected[0], result[0], "nullary def");
     assert_eq!(expected[1], result[1], "unary def");
     assert_eq!(expected[2], result[2], "recursive def");
     assert_eq!(expected[3], result[3], "long body");
+    assert_eq!(expected[4], result[4], "nameless");
+    assert_eq!(expected[5], result[5], "nameless with space");
     Ok(())
 }
 

--- a/tests/type_check/fail/functions/mod.rs
+++ b/tests/type_check/fail/functions/mod.rs
@@ -17,3 +17,19 @@ test_type!(
         found: Ty::Arrow(box Ty::Int, box Ty::Int),
     }))
 );
+
+test_type!(
+    wrong_type_anon_fn_call_arg,
+    Err(LangError::Ty(TyError::Mismatch {
+        expected: Ty::Int,
+        found: Ty::Bool
+    }))
+);
+
+test_type!(
+    wrong_return_type_anon_fn_int_to_int,
+    Err(LangError::Ty(TyError::Mismatch {
+        expected: Ty::Arrow(box Ty::Int, box Ty::Bool),
+        found: Ty::Arrow(box Ty::Int, box Ty::Int),
+    }))
+);

--- a/tests/type_check/fail/functions/wrong_return_type_anon_fn_int_to_int.pj
+++ b/tests/type_check/fail/functions/wrong_return_type_anon_fn_int_to_int.pj
@@ -1,0 +1,1 @@
+fn (x: Int): Bool do x end

--- a/tests/type_check/fail/functions/wrong_type_anon_fn_call_arg.pj
+++ b/tests/type_check/fail/functions/wrong_type_anon_fn_call_arg.pj
@@ -1,0 +1,3 @@
+foo = fn(n: Int) do 1 end
+
+foo(true)

--- a/tests/type_check/pass/functions/anon_fn_from_int_to_int.pj
+++ b/tests/type_check/pass/functions/anon_fn_from_int_to_int.pj
@@ -1,0 +1,1 @@
+fn(x: Int) do x end

--- a/tests/type_check/pass/functions/anon_fn_from_int_to_int_with_type.pj
+++ b/tests/type_check/pass/functions/anon_fn_from_int_to_int_with_type.pj
@@ -1,0 +1,1 @@
+fn(x: Int): Int do x end

--- a/tests/type_check/pass/functions/mod.rs
+++ b/tests/type_check/pass/functions/mod.rs
@@ -7,3 +7,11 @@ test_type!(
     fn_from_int_to_int_with_type,
     Ok(Ty::Arrow(box Ty::Int, box Ty::Int))
 );
+test_type!(
+    anon_fn_from_int_to_int,
+    Ok(Ty::Arrow(box Ty::Int, box Ty::Int))
+);
+test_type!(
+    anon_fn_from_int_to_int_with_type,
+    Ok(Ty::Arrow(box Ty::Int, box Ty::Int))
+);


### PR DESCRIPTION
Fixes https://github.com/christianpoveda/pijama/issues/33. This PR:
- Adds parsing support for anonymous functions with the syntax
```
fn(x: Int) do x end
```
- Changes the `Node::FnDef` variant in the AST to make the name of the function optional.
- Changes the lowering of the `Node::FnDef` to be a raw `Term::Abs` if the function definition has no name.
- Adds tests for parsing and type checking.
- Repurposes the `fancy_max` evaluation test to use an anonymous function.