### PR TITLE
Add location for AST nodes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 nom = "5.1.1"
+nom_locate = "2.0.0"
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 nom = "5.1.1"
 nom_locate = "2.0.0"
 thiserror = "1.0"
+codespan-reporting = "0.9.4"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -156,7 +156,7 @@ impl<'a> Display for Literal {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Node<'a> {
     BinaryOp(BinOp, Box<Located<Node<'a>>>, Box<Located<Node<'a>>>),
     UnaryOp(UnOp, Box<Located<Node<'a>>>),

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -2,7 +2,7 @@ use std::fmt::{self, Debug};
 
 use crate::ty::{Binding, Ty};
 
-pub type Block<'a> = Vec<Node<'a>>;
+pub type Block<'a> = Vec<Located<Node<'a>>>;
 
 #[derive(Debug, Clone, Copy)]
 pub struct Location {
@@ -150,13 +150,19 @@ impl<'a> fmt::Display for Literal {
     }
 }
 
-pub type Node<'a> = Located<NodeKind<'a>>;
-
 #[derive(Debug)]
-pub enum NodeKind<'a> {
-    BinaryOp(BinOp, Box<Node<'a>>, Box<Node<'a>>),
-    UnaryOp(UnOp, Box<Node<'a>>),
-    LetBind(Located<Name<'a>>, Option<Located<Ty>>, Box<Node<'a>>),
+pub enum Node<'a> {
+    BinaryOp(
+        BinOp,
+        Box<Located<Node<'a>>>,
+        Box<Located<Node<'a>>>,
+    ),
+    UnaryOp(UnOp, Box<Located<Node<'a>>>),
+    LetBind(
+        Located<Name<'a>>,
+        Option<Located<Ty>>,
+        Box<Located<Node<'a>>>,
+    ),
     Cond(Block<'a>, Block<'a>, Block<'a>),
     FnDef(
         Option<Located<Name<'a>>>,

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,8 +1,12 @@
 use std::fmt;
 
+use nom_locate::LocatedSpan;
+
 use crate::ty::{Binding, Ty};
 
 pub type Block<'a> = Vec<Node<'a>>;
+
+pub type Span<'a> = LocatedSpan<&'a str>;
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub struct Name<'a>(pub &'a str);
@@ -107,7 +111,13 @@ impl<'a> fmt::Display for Literal {
 }
 
 #[derive(Debug, Eq, PartialEq)]
-pub enum Node<'a> {
+pub struct Node<'a> {
+    pub span: Span<'a>,
+    pub kind: NodeKind<'a>,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum NodeKind<'a> {
     BinaryOp(BinOp, Box<Node<'a>>, Box<Node<'a>>),
     UnaryOp(UnOp, Box<Node<'a>>),
     LetBind(Name<'a>, Option<Ty>, Box<Node<'a>>),

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,4 +1,4 @@
-use std::fmt::{self, Debug};
+use std::fmt::{self, Debug, Display, Formatter};
 
 use crate::ty::{Binding, Ty};
 
@@ -39,6 +39,12 @@ impl<T: Debug> Located<T> {
     }
 }
 
+impl<T: Display + Debug> Display for Located<T> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}", self.content)
+    }
+}
+
 impl<T: Eq + Debug> Eq for Located<T> {}
 
 impl<T: PartialEq + Debug> PartialEq for Located<T> {
@@ -50,8 +56,8 @@ impl<T: PartialEq + Debug> PartialEq for Located<T> {
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct Name<'a>(pub &'a str);
 
-impl<'a> fmt::Display for Name<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl<'a> Display for Name<'a> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
@@ -78,8 +84,8 @@ pub enum BinOp {
     Gte,
 }
 
-impl<'a> fmt::Display for BinOp {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl<'a> Display for BinOp {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         use BinOp::*;
         match self {
             Add => write!(f, "+"),
@@ -110,8 +116,8 @@ pub enum UnOp {
     Not,
 }
 
-impl<'a> fmt::Display for UnOp {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl<'a> Display for UnOp {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         use UnOp::*;
         match self {
             Not => write!(f, "!"),
@@ -139,8 +145,8 @@ impl Into<Literal> for bool {
     }
 }
 
-impl<'a> fmt::Display for Literal {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl<'a> Display for Literal {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         use Literal::*;
         match self {
             Bool(b) => write!(f, "{}", b),
@@ -152,28 +158,24 @@ impl<'a> fmt::Display for Literal {
 
 #[derive(Debug)]
 pub enum Node<'a> {
-    BinaryOp(
-        BinOp,
-        Box<Located<Node<'a>>>,
-        Box<Located<Node<'a>>>,
-    ),
+    BinaryOp(BinOp, Box<Located<Node<'a>>>, Box<Located<Node<'a>>>),
     UnaryOp(UnOp, Box<Located<Node<'a>>>),
     LetBind(
         Located<Name<'a>>,
         Option<Located<Ty>>,
         Box<Located<Node<'a>>>,
     ),
-    Cond(Block<'a>, Block<'a>, Block<'a>),
+    Cond(Located<Block<'a>>, Located<Block<'a>>, Located<Block<'a>>),
     FnDef(
         Option<Located<Name<'a>>>,
         Vec<Located<Binding<'a>>>,
-        Block<'a>,
+        Located<Block<'a>>,
         Option<Located<Ty>>,
     ),
     FnRecDef(
         Located<Name<'a>>,
         Vec<Located<Binding<'a>>>,
-        Block<'a>,
+        Located<Block<'a>>,
         Located<Ty>,
     ),
     Call(Located<Name<'a>>, Block<'a>),

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,12 +1,8 @@
-use std::fmt;
-
-use nom_locate::LocatedSpan;
+use std::fmt::{self, Debug};
 
 use crate::ty::{Binding, Ty};
 
 pub type Block<'a> = Vec<Node<'a>>;
-
-pub type Span<'a> = LocatedSpan<&'a str>;
 
 #[derive(Debug, Clone, Copy)]
 pub struct Location {
@@ -28,16 +24,6 @@ impl std::ops::Add for Location {
     }
 }
 
-impl<'a> From<Span<'a>> for Location {
-    fn from(span: Span<'a>) -> Self {
-        let start = span.location_offset();
-        let end = start + span.fragment().len();
-        Location { start, end }
-    }
-}
-
-use fmt::Debug;
-
 #[derive(Debug)]
 pub struct Located<T: Debug> {
     pub content: T,
@@ -45,8 +31,11 @@ pub struct Located<T: Debug> {
 }
 
 impl<T: Debug> Located<T> {
-    pub fn new(content: T, loc: Location) -> Self {
-        Located { content, loc }
+    pub fn new(content: T, loc: impl Into<Location>) -> Self {
+        Located {
+            content,
+            loc: loc.into(),
+        }
     }
 }
 

--- a/src/ast/location.rs
+++ b/src/ast/location.rs
@@ -1,0 +1,50 @@
+use std::fmt::{Debug, Display, Formatter, Result};
+
+#[derive(Debug, Clone, Copy)]
+pub struct Location {
+    pub start: usize,
+    pub end: usize,
+}
+
+impl Location {
+    pub fn new(start: usize, end: usize) -> Self {
+        Location { start, end }
+    }
+}
+
+impl std::ops::Add for Location {
+    type Output = Self;
+    fn add(mut self, other: Self) -> Self {
+        self.end = other.end;
+        self
+    }
+}
+
+#[derive(Debug)]
+pub struct Located<T: Debug> {
+    pub content: T,
+    pub loc: Location,
+}
+
+impl<T: Debug> Located<T> {
+    pub fn new(content: T, loc: impl Into<Location>) -> Self {
+        Located {
+            content,
+            loc: loc.into(),
+        }
+    }
+}
+
+impl<T: Display + Debug> Display for Located<T> {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        write!(f, "{}", self.content)
+    }
+}
+
+impl<T: Eq + Debug> Eq for Located<T> {}
+
+impl<T: PartialEq + Debug> PartialEq for Located<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.content == other.content
+    }
+}

--- a/src/ast/location.rs
+++ b/src/ast/location.rs
@@ -1,6 +1,5 @@
 use std::fmt::{Debug, Display, Formatter, Result};
 
-
 /// Represents a location in the source code file.
 ///
 /// Both the start and end correspond to locations reported by `nom_locate`.

--- a/src/ast/location.rs
+++ b/src/ast/location.rs
@@ -1,8 +1,14 @@
 use std::fmt::{Debug, Display, Formatter, Result};
 
+
+/// Represents a location in the source code file.
+///
+/// Both the start and end correspond to locations reported by `nom_locate`.
 #[derive(Debug, Clone, Copy)]
 pub struct Location {
+    /// Start of the location
     pub start: usize,
+    /// End of the location
     pub end: usize,
 }
 
@@ -12,6 +18,8 @@ impl Location {
     }
 }
 
+/// Adding two locations `l1` and `l2` returns a location starting in `l1.start` and ending in
+/// `l2.end`.
 impl std::ops::Add for Location {
     type Output = Self;
     fn add(mut self, other: Self) -> Self {
@@ -20,9 +28,14 @@ impl std::ops::Add for Location {
     }
 }
 
+/// Wrapper type with a `Location` field.
+///
+/// It is used to add a location to elements in the AST and intermediate representations.
 #[derive(Debug)]
 pub struct Located<T: Debug> {
+    /// Content of the wrapper.
     pub content: T,
+    /// Location of `content` in the source file.
     pub loc: Location,
 }
 

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1,63 +1,18 @@
-use std::fmt::{self, Debug, Display, Formatter};
+use std::fmt::{Debug, Display, Formatter, Result};
 
 use crate::ty::{Binding, Ty};
 
+mod location;
+
+pub use location::*;
+
 pub type Block<'a> = Vec<Located<Node<'a>>>;
-
-#[derive(Debug, Clone, Copy)]
-pub struct Location {
-    pub start: usize,
-    pub end: usize,
-}
-
-impl Location {
-    pub fn new(start: usize, end: usize) -> Self {
-        Location { start, end }
-    }
-}
-
-impl std::ops::Add for Location {
-    type Output = Self;
-    fn add(mut self, other: Self) -> Self {
-        self.end = other.end;
-        self
-    }
-}
-
-#[derive(Debug)]
-pub struct Located<T: Debug> {
-    pub content: T,
-    pub loc: Location,
-}
-
-impl<T: Debug> Located<T> {
-    pub fn new(content: T, loc: impl Into<Location>) -> Self {
-        Located {
-            content,
-            loc: loc.into(),
-        }
-    }
-}
-
-impl<T: Display + Debug> Display for Located<T> {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{}", self.content)
-    }
-}
-
-impl<T: Eq + Debug> Eq for Located<T> {}
-
-impl<T: PartialEq + Debug> PartialEq for Located<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.content == other.content
-    }
-}
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct Name<'a>(pub &'a str);
 
 impl<'a> Display for Name<'a> {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> Result {
         write!(f, "{}", self.0)
     }
 }
@@ -85,7 +40,7 @@ pub enum BinOp {
 }
 
 impl<'a> Display for BinOp {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> Result {
         use BinOp::*;
         match self {
             Add => write!(f, "+"),
@@ -117,7 +72,7 @@ pub enum UnOp {
 }
 
 impl<'a> Display for UnOp {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> Result {
         use UnOp::*;
         match self {
             Not => write!(f, "!"),
@@ -146,7 +101,7 @@ impl Into<Literal> for bool {
 }
 
 impl<'a> Display for Literal {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> Result {
         use Literal::*;
         match self {
             Bool(b) => write!(f, "{}", b),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,11 +28,13 @@ impl<'a> From<ParseError<'a>> for LangError<'a> {
         LangError::Parse(err)
     }
 }
-use codespan_reporting::diagnostic::{Diagnostic, Label};
-use codespan_reporting::files::SimpleFiles;
-use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
+use codespan_reporting::{
+    diagnostic::{Diagnostic, Label},
+    files::SimpleFiles,
+    term::termcolor::{ColorChoice, StandardStream},
+};
 
-pub fn display_error<'a>(input: &str, path:&str, error: LangError<'a>) {
+pub fn display_error<'a>(input: &str, path: &str, error: LangError<'a>) {
     let writer = StandardStream::stderr(ColorChoice::Always);
     let config = codespan_reporting::term::Config::default();
     let mut files = SimpleFiles::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,8 @@ pub mod ty;
 
 use thiserror::Error;
 
-use machine::Machine;
 use ast::Location;
+use machine::Machine;
 use parser::ParseError;
 use ty::TyError;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,33 @@ impl<'a> From<ParseError<'a>> for LangError<'a> {
         LangError::Parse(err)
     }
 }
+use codespan_reporting::diagnostic::{Diagnostic, Label};
+use codespan_reporting::files::SimpleFiles;
+use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
+
+pub fn display_error<'a>(input: &str, path:&str, error: LangError<'a>) {
+    let writer = StandardStream::stderr(ColorChoice::Always);
+    let config = codespan_reporting::term::Config::default();
+    let mut files = SimpleFiles::new();
+
+    let file_id = files.add(path, input);
+
+    match error {
+        LangError::Ty(error) => eprintln!("{}", error),
+        LangError::Parse(error) => {
+            let span = error.span;
+            let begin = span.location_offset();
+            let diagnostic = Diagnostic::error()
+                .with_message("Parsing failed")
+                .with_labels(vec![
+                    Label::primary(file_id, begin..input.len()).with_message(format!("{}", error))
+                ]);
+
+            codespan_reporting::term::emit(&mut writer.lock(), &config, &files, &diagnostic)
+                .unwrap();
+        }
+    }
+}
 
 pub fn run(input: &str) -> LangResult<lir::Term> {
     let ast = parser::parse(input)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,9 @@
 
 use thiserror::Error;
 
-use crate::machine::Machine;
+use machine::Machine;
+use parser::ParseError;
+use ty::TyError;
 
 pub mod ast;
 pub mod lir;
@@ -11,14 +13,20 @@ pub mod mir;
 pub mod parser;
 pub mod ty;
 
-pub type LangResult<T> = Result<T, LangError>;
+pub type LangResult<'a, T> = Result<T, LangError<'a>>;
 
 #[derive(Error, Debug)]
-pub enum LangError {
-    #[error("{0}")]
-    Ty(#[from] ty::TyError),
-    #[error("{0}")]
-    Parse(String),
+pub enum LangError<'a> {
+    #[error("Type error: {0}")]
+    Ty(#[from] TyError),
+    #[error("Parse error: {0}")]
+    Parse(ParseError<'a>),
+}
+
+impl<'a> From<ParseError<'a>> for LangError<'a> {
+    fn from(err: ParseError<'a>) -> Self {
+        LangError::Parse(err)
+    }
 }
 
 pub fn run(input: &str) -> LangResult<lir::Term> {

--- a/src/lir.rs
+++ b/src/lir.rs
@@ -36,7 +36,7 @@ impl fmt::Display for Term {
 }
 
 impl Term {
-    pub fn from_mir(mir: crate::mir::Term) -> Self {
+    pub fn from_mir(mir: Located<crate::mir::Term>) -> Self {
         ctx::remove_names(mir)
     }
 

--- a/src/lir/ctx.rs
+++ b/src/lir/ctx.rs
@@ -1,7 +1,10 @@
-use crate::{ast::Name, lir, mir};
+use crate::{
+    ast::{Located, Name},
+    lir, mir,
+};
 
-pub fn remove_names(term: mir::Term<'_>) -> lir::Term {
-    Context::default().remove_names(term)
+pub fn remove_names(term: Located<mir::Term<'_>>) -> lir::Term {
+    Context::default().remove_names(term.content)
 }
 
 #[derive(Default)]
@@ -25,44 +28,44 @@ impl<'a> Context<'a> {
             }
             mir::Term::Abs(bind, body) => {
                 self.inner.push(bind.name);
-                let body = self.remove_names(*body);
+                let body = self.remove_names(body.content);
                 self.inner.pop().unwrap();
                 lir::Term::Abs(Box::new(body))
             }
             mir::Term::UnaryOp(op, t1) => {
-                let t1 = self.remove_names(*t1);
+                let t1 = self.remove_names(t1.content);
                 lir::Term::UnaryOp(op, Box::new(t1))
             }
             mir::Term::BinaryOp(op, t1, t2) => {
-                let t1 = self.remove_names(*t1);
-                let t2 = self.remove_names(*t2);
+                let t1 = self.remove_names(t1.content);
+                let t2 = self.remove_names(t2.content);
                 lir::Term::BinaryOp(op, Box::new(t1), Box::new(t2))
             }
             mir::Term::App(t1, t2) => {
-                let t1 = self.remove_names(*t1);
-                let t2 = self.remove_names(*t2);
+                let t1 = self.remove_names(t1.content);
+                let t2 = self.remove_names(t2.content);
                 lir::Term::App(Box::new(t1), Box::new(t2))
             }
             mir::Term::Let(name, t1, t2) => {
-                let t1 = self.remove_names(*t1);
-                self.inner.push(name);
-                let t2 = self.remove_names(*t2);
+                let t1 = self.remove_names(t1.content);
+                self.inner.push(name.content);
+                let t2 = self.remove_names(t2.content);
                 self.inner.pop().unwrap();
                 lir::Term::App(Box::new(lir::Term::Abs(Box::new(t2))), Box::new(t1))
             }
             mir::Term::Cond(t1, t2, t3) => {
-                let t1 = self.remove_names(*t1);
-                let t2 = self.remove_names(*t2);
-                let t3 = self.remove_names(*t3);
+                let t1 = self.remove_names(t1.content);
+                let t2 = self.remove_names(t2.content);
+                let t3 = self.remove_names(t3.content);
                 lir::Term::Cond(Box::new(t1), Box::new(t2), Box::new(t3))
             }
             mir::Term::Seq(t1, t2) => {
-                let t1 = self.remove_names(*t1);
-                let t2 = self.remove_names(*t2);
+                let t1 = self.remove_names(t1.content);
+                let t2 = self.remove_names(t2.content);
                 lir::Term::App(Box::new(lir::Term::Abs(Box::new(t2))), Box::new(t1))
             }
             mir::Term::Fix(t1) => {
-                let t1 = self.remove_names(*t1);
+                let t1 = self.remove_names(t1.content);
                 lir::Term::Fix(Box::new(t1))
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,14 @@
 use std::{env::args, fs::read_to_string};
 
-use pijama::run;
+use pijama::{run, display_error};
 
 fn main() {
     let mut args = args();
     args.next().unwrap();
     let path = args.next().expect("no path to source code");
-    let input = read_to_string(path).unwrap();
+    let input = read_to_string(&path).unwrap();
     match run(&input) {
         Ok(term) => println!("{}", term),
-        Err(e) => eprintln!("{}", e),
+        Err(e) => display_error(&input, &path, e),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use std::{env::args, fs::read_to_string};
 
-use pijama::{run, display_error};
+use pijama::{display_error, run};
 
 fn main() {
     let mut args = args();

--- a/src/mir.rs
+++ b/src/mir.rs
@@ -62,19 +62,19 @@ fn lower_blk<'a>(blk: Block<'a>) -> TyResult<Term<'a>> {
     }
 }
 
-fn lower_node(node: Node<'_>) -> TyResult<Term<'_>> {
+fn lower_node(node: Located<Node<'_>>) -> TyResult<Term<'_>> {
     match node.content {
-        NodeKind::Name(name) => Ok(Term::Var(name)),
-        NodeKind::Cond(if_blk, do_blk, el_blk) => lower_cond(if_blk, do_blk, el_blk),
-        NodeKind::Literal(lit) => Ok(Term::Lit(lit)),
-        NodeKind::Call(name, args) => lower_call(name, args),
-        NodeKind::BinaryOp(bin_op, node1, node2) => lower_binary_op(bin_op, *node1, *node2),
-        NodeKind::UnaryOp(un_op, node) => lower_unary_op(un_op, *node),
-        NodeKind::LetBind(name, opt_ty, node) => lower_let_bind(name, opt_ty, *node),
-        NodeKind::FnDef(opt_name, binds, body, opt_ty) => {
+        Node::Name(name) => Ok(Term::Var(name)),
+        Node::Cond(if_blk, do_blk, el_blk) => lower_cond(if_blk, do_blk, el_blk),
+        Node::Literal(lit) => Ok(Term::Lit(lit)),
+        Node::Call(name, args) => lower_call(name, args),
+        Node::BinaryOp(bin_op, node1, node2) => lower_binary_op(bin_op, *node1, *node2),
+        Node::UnaryOp(un_op, node) => lower_unary_op(un_op, *node),
+        Node::LetBind(name, opt_ty, node) => lower_let_bind(name, opt_ty, *node),
+        Node::FnDef(opt_name, binds, body, opt_ty) => {
             lower_fn_def(opt_name, binds, body, opt_ty)
         }
-        NodeKind::FnRecDef(name, binds, body, ty) => lower_fn_rec_def(name, binds, body, ty),
+        Node::FnRecDef(name, binds, body, ty) => lower_fn_rec_def(name, binds, body, ty),
     }
 }
 
@@ -94,7 +94,11 @@ fn lower_call<'a>(name: Located<Name<'a>>, args: Block<'a>) -> TyResult<Term<'a>
     Ok(term)
 }
 
-fn lower_binary_op<'a>(bin_op: BinOp, node1: Node<'a>, node2: Node<'a>) -> TyResult<Term<'a>> {
+fn lower_binary_op<'a>(
+    bin_op: BinOp,
+    node1: Located<Node<'a>>,
+    node2: Located<Node<'a>>,
+) -> TyResult<Term<'a>> {
     Ok(Term::BinaryOp(
         bin_op,
         Box::new(lower_node(node1)?),
@@ -102,14 +106,14 @@ fn lower_binary_op<'a>(bin_op: BinOp, node1: Node<'a>, node2: Node<'a>) -> TyRes
     ))
 }
 
-fn lower_unary_op(un_op: UnOp, node: Node<'_>) -> TyResult<Term<'_>> {
+fn lower_unary_op(un_op: UnOp, node: Located<Node<'_>>) -> TyResult<Term<'_>> {
     Ok(Term::UnaryOp(un_op, Box::new(lower_node(node)?)))
 }
 
 fn lower_let_bind<'a>(
     name: Located<Name<'a>>,
     opt_ty: Option<Located<Ty>>,
-    node: Node<'a>,
+    node: Located<Node<'a>>,
 ) -> TyResult<Term<'a>> {
     let name = name.content;
     let opt_ty = opt_ty.map(|l| l.content);

--- a/src/mir.rs
+++ b/src/mir.rs
@@ -63,16 +63,18 @@ fn lower_blk<'a>(blk: Block<'a>) -> TyResult<Term<'a>> {
 }
 
 fn lower_node(node: Node<'_>) -> TyResult<Term<'_>> {
-    match node {
-        Node::Name(name) => Ok(Term::Var(name)),
-        Node::Cond(if_blk, do_blk, el_blk) => lower_cond(if_blk, do_blk, el_blk),
-        Node::Literal(lit) => Ok(Term::Lit(lit)),
-        Node::Call(name, args) => lower_call(name, args),
-        Node::BinaryOp(bin_op, node1, node2) => lower_binary_op(bin_op, *node1, *node2),
-        Node::UnaryOp(un_op, node) => lower_unary_op(un_op, *node),
-        Node::LetBind(name, opt_ty, node) => lower_let_bind(name, opt_ty, *node),
-        Node::FnDef(opt_name, binds, body, opt_ty) => lower_fn_def(opt_name, binds, body, opt_ty),
-        Node::FnRecDef(name, binds, body, ty) => lower_fn_rec_def(name, binds, body, ty),
+    match node.kind {
+        NodeKind::Name(name) => Ok(Term::Var(name)),
+        NodeKind::Cond(if_blk, do_blk, el_blk) => lower_cond(if_blk, do_blk, el_blk),
+        NodeKind::Literal(lit) => Ok(Term::Lit(lit)),
+        NodeKind::Call(name, args) => lower_call(name, args),
+        NodeKind::BinaryOp(bin_op, node1, node2) => lower_binary_op(bin_op, *node1, *node2),
+        NodeKind::UnaryOp(un_op, node) => lower_unary_op(un_op, *node),
+        NodeKind::LetBind(name, opt_ty, node) => lower_let_bind(name, opt_ty, *node),
+        NodeKind::FnDef(opt_name, binds, body, opt_ty) => {
+            lower_fn_def(opt_name, binds, body, opt_ty)
+        }
+        NodeKind::FnRecDef(name, binds, body, ty) => lower_fn_rec_def(name, binds, body, ty),
     }
 }
 

--- a/src/mir.rs
+++ b/src/mir.rs
@@ -2,7 +2,8 @@ use std::fmt;
 
 use crate::{
     ast::*,
-    ty::{expect_ty, ty_check, Binding, Ty, TyResult},
+    ensure_ty,
+    ty::{ty_check, Binding, Ty, TyResult},
     LangError, LangResult,
 };
 
@@ -156,7 +157,7 @@ fn lower_let_bind<'a>(
 
     if let Some(ty) = opt_ty {
         let term_ty = ty_check(&term)?;
-        expect_ty(ty.content, term_ty)?;
+        ensure_ty!(ty.content, term_ty)?;
     }
 
     Ok(Located::new(
@@ -196,7 +197,7 @@ fn lower_fn_def<'a>(
 
     if let Some(ty) = opt_ty {
         let term_ty = ty_check(&term)?;
-        expect_ty(ty, term_ty)?;
+        ensure_ty!(ty, term_ty)?;
     }
 
     if let Some(name) = opt_name {

--- a/src/mir.rs
+++ b/src/mir.rs
@@ -2,8 +2,7 @@ use std::fmt;
 
 use crate::{
     ast::*,
-    ensure_ty,
-    ty::{ty_check, Binding, Ty, TyResult},
+    ty::{expect_ty, ty_check, Binding, Ty, TyResult},
     LangError, LangResult,
 };
 
@@ -157,7 +156,7 @@ fn lower_let_bind<'a>(
 
     if let Some(ty) = opt_ty {
         let term_ty = ty_check(&term)?;
-        ensure_ty!(ty.content, term_ty)?;
+        expect_ty(ty.content, term_ty)?;
     }
 
     Ok(Located::new(
@@ -197,7 +196,7 @@ fn lower_fn_def<'a>(
 
     if let Some(ty) = opt_ty {
         let term_ty = ty_check(&term)?;
-        ensure_ty!(ty, term_ty)?;
+        expect_ty(ty, term_ty)?;
     }
 
     if let Some(name) = opt_name {

--- a/src/parser/bin_op.rs
+++ b/src/parser/bin_op.rs
@@ -17,11 +17,8 @@ use nom::{
 };
 
 use crate::{
-    ast::{
-        BinOp::{self, *},
-        Span,
-    },
-    parser::{helpers::surrounded, IResult},
+    ast::{BinOp, BinOp::*},
+    parser::{helpers::surrounded, IResult, Span},
 };
 
 /// Parser for the binary operators with precedence level 1.

--- a/src/parser/bin_op.rs
+++ b/src/parser/bin_op.rs
@@ -13,9 +13,7 @@ use nom::{
     bytes::complete::tag,
     character::complete::{char, space0},
     combinator::{map, not, peek},
-    error::ParseError,
     sequence::terminated,
-    IResult,
 };
 
 use crate::{
@@ -23,7 +21,7 @@ use crate::{
         BinOp::{self, *},
         Span,
     },
-    parser::helpers::surrounded,
+    parser::{helpers::surrounded, IResult},
 };
 
 /// Parser for the binary operators with precedence level 1.
@@ -31,7 +29,7 @@ use crate::{
 /// These operators are `&&` and `||`.
 ///
 /// All the binary operators might be surronded by zero or more spaces.
-pub fn bin_op_1<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, BinOp, E> {
+pub fn bin_op_1(input: Span) -> IResult<BinOp> {
     surrounded(
         alt((map(tag("&&"), |_| And), map(tag("||"), |_| Or))),
         space0,
@@ -46,7 +44,7 @@ pub fn bin_op_1<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a
 /// and `<<` operators.
 ///
 /// All the binary operators might be surronded by zero or more spaces.
-pub fn bin_op_2<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, BinOp, E> {
+pub fn bin_op_2(input: Span) -> IResult<BinOp> {
     surrounded(
         alt((
             map(tag("<="), |_| Lte),
@@ -68,7 +66,7 @@ pub fn bin_op_2<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a
 /// and `||` operators.
 ///
 /// All the binary operators might be surronded by zero or more spaces.
-pub fn bin_op_3<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, BinOp, E> {
+pub fn bin_op_3(input: Span) -> IResult<BinOp> {
     surrounded(
         alt((
             map(terminated(char('&'), peek(not(char('&')))), |_| BitAnd),
@@ -86,7 +84,7 @@ pub fn bin_op_3<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a
 /// These operators are `+` and `-`.
 ///
 /// All the binary operators might be surronded by zero or more spaces.
-pub fn bin_op_4<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, BinOp, E> {
+pub fn bin_op_4(input: Span) -> IResult<BinOp> {
     surrounded(
         alt((map(char('+'), |_| Add), map(char('-'), |_| Sub))),
         space0,
@@ -98,7 +96,7 @@ pub fn bin_op_4<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a
 /// These operators are `*`, `/` and `%`.
 ///
 /// All the binary operators might be surronded by zero or more spaces.
-pub fn bin_op_5<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, BinOp, E> {
+pub fn bin_op_5(input: Span) -> IResult<BinOp> {
     surrounded(
         alt((
             map(char('*'), |_| Mul),

--- a/src/parser/bin_op.rs
+++ b/src/parser/bin_op.rs
@@ -19,7 +19,10 @@ use nom::{
 };
 
 use crate::{
-    ast::BinOp::{self, *},
+    ast::{
+        BinOp::{self, *},
+        Span,
+    },
     parser::helpers::surrounded,
 };
 
@@ -28,7 +31,7 @@ use crate::{
 /// These operators are `&&` and `||`.
 ///
 /// All the binary operators might be surronded by zero or more spaces.
-pub fn bin_op_1<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, BinOp, E> {
+pub fn bin_op_1<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, BinOp, E> {
     surrounded(
         alt((map(tag("&&"), |_| And), map(tag("||"), |_| Or))),
         space0,
@@ -43,7 +46,7 @@ pub fn bin_op_1<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, 
 /// and `<<` operators.
 ///
 /// All the binary operators might be surronded by zero or more spaces.
-pub fn bin_op_2<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, BinOp, E> {
+pub fn bin_op_2<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, BinOp, E> {
     surrounded(
         alt((
             map(tag("<="), |_| Lte),
@@ -65,7 +68,7 @@ pub fn bin_op_2<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, 
 /// and `||` operators.
 ///
 /// All the binary operators might be surronded by zero or more spaces.
-pub fn bin_op_3<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, BinOp, E> {
+pub fn bin_op_3<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, BinOp, E> {
     surrounded(
         alt((
             map(terminated(char('&'), peek(not(char('&')))), |_| BitAnd),
@@ -83,7 +86,7 @@ pub fn bin_op_3<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, 
 /// These operators are `+` and `-`.
 ///
 /// All the binary operators might be surronded by zero or more spaces.
-pub fn bin_op_4<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, BinOp, E> {
+pub fn bin_op_4<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, BinOp, E> {
     surrounded(
         alt((map(char('+'), |_| Add), map(char('-'), |_| Sub))),
         space0,
@@ -95,7 +98,7 @@ pub fn bin_op_4<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, 
 /// These operators are `*`, `/` and `%`.
 ///
 /// All the binary operators might be surronded by zero or more spaces.
-pub fn bin_op_5<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, BinOp, E> {
+pub fn bin_op_5<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, BinOp, E> {
     surrounded(
         alt((
             map(char('*'), |_| Mul),

--- a/src/parser/block.rs
+++ b/src/parser/block.rs
@@ -10,8 +10,8 @@ use nom::{
 };
 
 use crate::{
-    ast::{Block, Span},
-    parser::{node::node, IResult},
+    ast::Block,
+    parser::{node::node, IResult, Span},
 };
 
 /// Parser for [`Block`]s.

--- a/src/parser/block.rs
+++ b/src/parser/block.rs
@@ -12,18 +12,20 @@ use nom::{
     IResult,
 };
 
-use crate::{ast::Block, parser::node::node};
+use crate::ast::{Block, Span};
+
+use crate::parser::node::node;
 
 /// Parser for [`Block`]s.
 ///
 /// Nodes in the block can be separated by at least one line break and optional spaces.
-pub fn block0<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Block, E> {
+pub fn block0<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Block<'a>, E> {
     separated_list(line_ending, preceded(multispace0, node))(input)
 }
 
 /// Parser for non-empty [`Block`]s.
 ///
 /// Nodes in the block can be separated by at least one line break and optional spaces.
-pub fn block1<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Block, E> {
+pub fn block1<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Block<'a>, E> {
     separated_nonempty_list(line_ending, preceded(multispace0, node))(input)
 }

--- a/src/parser/block.rs
+++ b/src/parser/block.rs
@@ -19,6 +19,11 @@ use crate::{
 /// Parser for [`Block`]s.
 ///
 /// Nodes in the block can be separated by at least one line break and optional spaces.
+///
+/// The location of this element matches the start of the first space or line break before the
+/// first `Node` of the `Block`. If there is no spaces or line breaks before the first `Node`, the
+/// start matches the start of the `Node`. The end of the location is handled in an analogous
+/// manner.
 pub fn block0(input: Span) -> IResult<Located<Block>> {
     map(
         tuple((
@@ -36,6 +41,11 @@ pub fn block0(input: Span) -> IResult<Located<Block>> {
 /// Parser for non-empty [`Block`]s.
 ///
 /// Nodes in the block can be separated by at least one line break and optional spaces.
+///
+/// The location of this element matches the start of the first space or line break before the
+/// first `Node` of the `Block`. If there is no spaces or line breaks before the first `Node`, the
+/// start matches the start of the `Node`. The end of the location is handled in an analogous
+/// manner.
 pub fn block1(input: Span) -> IResult<Located<Block>> {
     map(
         tuple((

--- a/src/parser/block.rs
+++ b/src/parser/block.rs
@@ -3,29 +3,27 @@
 //! The [`block0`] parser is the top-level parser of the whole [`parser`] module.
 //!
 //! [`parser`]: crate::parser
-
 use nom::{
     character::complete::{line_ending, multispace0},
-    error::ParseError,
     multi::{separated_list, separated_nonempty_list},
     sequence::preceded,
-    IResult,
 };
 
-use crate::ast::{Block, Span};
-
-use crate::parser::node::node;
+use crate::{
+    ast::{Block, Span},
+    parser::{node::node, IResult},
+};
 
 /// Parser for [`Block`]s.
 ///
 /// Nodes in the block can be separated by at least one line break and optional spaces.
-pub fn block0<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Block<'a>, E> {
+pub fn block0(input: Span) -> IResult<Block> {
     separated_list(line_ending, preceded(multispace0, node))(input)
 }
 
 /// Parser for non-empty [`Block`]s.
 ///
 /// Nodes in the block can be separated by at least one line break and optional spaces.
-pub fn block1<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Block<'a>, E> {
+pub fn block1(input: Span) -> IResult<Block> {
     separated_nonempty_list(line_ending, preceded(multispace0, node))(input)
 }

--- a/src/parser/block.rs
+++ b/src/parser/block.rs
@@ -5,25 +5,47 @@
 //! [`parser`]: crate::parser
 use nom::{
     character::complete::{line_ending, multispace0},
+    combinator::map,
     multi::{separated_list, separated_nonempty_list},
-    sequence::preceded,
+    sequence::{preceded, tuple},
 };
+use nom_locate::position;
 
 use crate::{
-    ast::Block,
+    ast::{Block, Located, Location},
     parser::{node::node, IResult, Span},
 };
 
 /// Parser for [`Block`]s.
 ///
 /// Nodes in the block can be separated by at least one line break and optional spaces.
-pub fn block0(input: Span) -> IResult<Block> {
-    separated_list(line_ending, preceded(multispace0, node))(input)
+pub fn block0(input: Span) -> IResult<Located<Block>> {
+    map(
+        tuple((
+            position,
+            separated_list(line_ending, preceded(multispace0, node)),
+            position,
+        )),
+        |(sp1, content, sp2)| {
+            let loc = Location::from(sp1) + Location::from(sp2);
+            Located::new(content, loc)
+        },
+    )(input)
 }
 
 /// Parser for non-empty [`Block`]s.
 ///
 /// Nodes in the block can be separated by at least one line break and optional spaces.
-pub fn block1(input: Span) -> IResult<Block> {
-    separated_nonempty_list(line_ending, preceded(multispace0, node))(input)
+pub fn block1(input: Span) -> IResult<Located<Block>> {
+    map(
+        tuple((
+            position,
+            separated_nonempty_list(line_ending, preceded(multispace0, node)),
+            position,
+        )),
+        |(sp1, content, sp2)| {
+            let loc = Location::from(sp1) + Location::from(sp2);
+            Located::new(content, loc)
+        },
+    )(input)
 }

--- a/src/parser/helpers.rs
+++ b/src/parser/helpers.rs
@@ -9,7 +9,10 @@ use nom::{
 };
 use nom_locate::position;
 
-use crate::ast::{Located, Location, Span};
+use crate::{
+    ast::{Located, Location},
+    parser::Span,
+};
 
 /// Helper parser for expressions surrounded by a delimiter.
 ///

--- a/src/parser/helpers.rs
+++ b/src/parser/helpers.rs
@@ -8,6 +8,8 @@ use nom::{
     IResult,
 };
 
+use crate::ast::Span;
+
 /// Helper parser for expressions surrounded by a delimiter.
 ///
 /// The output only contains the expression without the delimiters.
@@ -22,9 +24,9 @@ pub fn surrounded<I, O, O2, E: ParseError<I>>(
 ///
 /// The output only contains the expression without the brackets and there can be any number of
 /// spaces or line breaks between the actual content and the brackets.
-pub fn in_brackets<'a, O, E: ParseError<&'a str>>(
-    content: impl Fn(&'a str) -> IResult<&'a str, O, E>,
-) -> impl Fn(&'a str) -> IResult<&'a str, O, E> {
+pub fn in_brackets<'a, O, E: ParseError<Span<'a>>>(
+    content: impl Fn(Span<'a>) -> IResult<Span<'a>, O, E>,
+) -> impl Fn(Span<'a>) -> IResult<Span<'a>, O, E> {
     delimited(char('('), surrounded(content, multispace0), char(')'))
 }
 
@@ -36,9 +38,9 @@ pub fn in_brackets<'a, O, E: ParseError<&'a str>>(
 ///
 /// This is particularly useful when you are sure that there is only one expression that can be
 /// parsed after a certain hint.
-pub fn lookahead<'a, O, O2, E: ParseError<&'a str>>(
-    hint: impl Fn(&'a str) -> IResult<&'a str, O2, E>,
-    content: impl Fn(&'a str) -> IResult<&'a str, O, E>,
-) -> impl Fn(&'a str) -> IResult<&'a str, O, E> {
+pub fn lookahead<'a, O, O2, E: ParseError<Span<'a>>>(
+    hint: impl Fn(Span<'a>) -> IResult<Span<'a>, O2, E>,
+    content: impl Fn(Span<'a>) -> IResult<Span<'a>, O, E>,
+) -> impl Fn(Span<'a>) -> IResult<Span<'a>, O, E> {
     preceded(peek(hint), cut(content))
 }

--- a/src/parser/helpers.rs
+++ b/src/parser/helpers.rs
@@ -28,6 +28,8 @@ pub fn surrounded<I, O, O2, E: ParseError<I>>(
 ///
 /// The output only contains the expression without the brackets and there can be any number of
 /// spaces or line breaks between the actual content and the brackets.
+///
+/// The location of this element starts in the `(` and ends in the `)`.
 pub fn in_brackets<'a, O: std::fmt::Debug, E: ParseError<Span<'a>>>(
     content: impl Fn(Span<'a>) -> IResult<Span<'a>, O, E>,
 ) -> impl Fn(Span<'a>) -> IResult<Span<'a>, Located<O>, E> {

--- a/src/parser/literal.rs
+++ b/src/parser/literal.rs
@@ -12,13 +12,13 @@ use nom::{
     IResult,
 };
 
-use crate::ast::Literal;
+use crate::ast::{Literal, Span};
 
 /// Parses a [`Literal`](crate::ast::Literal).
 ///
 /// The only valid inputs for this parser are `"true"`, `"false"`, `"unit"` or a signed integer
 /// (which is parsed by the [`number`](number) parser).
-pub fn literal<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Literal, E> {
+pub fn literal<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Literal, E> {
     alt((
         map(tag("true"), |_| Literal::Bool(true)),
         map(tag("false"), |_| Literal::Bool(false)),
@@ -34,11 +34,11 @@ pub fn literal<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, L
 ///
 /// If the number is negative, there cannot be spaces between the minus sign and the digits of the
 /// number. That kind of expression will be parsed as an unary operation.
-fn number<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, i128, E> {
+fn number<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, i128, E> {
     map_opt(
         pair(opt(char('-')), digit1),
-        |(sign, digits): (Option<char>, &str)| {
-            let mut number = digits.parse::<i128>().ok()?;
+        |(sign, digits_span): (Option<char>, Span)| {
+            let mut number = digits_span.fragment().parse::<i128>().ok()?;
             if sign.is_some() {
                 number *= -1;
             }

--- a/src/parser/literal.rs
+++ b/src/parser/literal.rs
@@ -10,8 +10,8 @@ use nom::{
 };
 
 use crate::{
-    ast::{Literal, Located, Location, Span},
-    parser::IResult,
+    ast::{Literal, Located, Location},
+    parser::{IResult, Span},
 };
 
 /// Parses a [`Literal`](crate::ast::Literal).
@@ -21,14 +21,12 @@ use crate::{
 pub fn literal(input: Span) -> IResult<Located<Literal>> {
     alt((
         map(tag("true"), |span: Span| {
-            Located::new(Literal::Bool(true), span.into())
+            Located::new(Literal::Bool(true), span)
         }),
         map(tag("false"), |span: Span| {
-            Located::new(Literal::Bool(false), span.into())
+            Located::new(Literal::Bool(false), span)
         }),
-        map(tag("unit"), |span: Span| {
-            Located::new(Literal::Unit, span.into())
-        }),
+        map(tag("unit"), |span: Span| Located::new(Literal::Unit, span)),
         map(number, |Located { content, loc }| {
             Located::new(Literal::Number(content), loc)
         }),
@@ -47,7 +45,7 @@ fn number(input: Span) -> IResult<Located<i128>> {
         pair(opt(char('-')), digit1),
         |(sign, digits_span): (Option<char>, Span)| {
             let mut number = digits_span.fragment().parse::<i128>().ok()?;
-            let mut loc = Location::from(digits_span);
+            let mut loc: Location = digits_span.into();
 
             if sign.is_some() {
                 loc.start -= 1;

--- a/src/parser/literal.rs
+++ b/src/parser/literal.rs
@@ -1,24 +1,24 @@
 //! Parsers for literals.
 //!
 //! The entry point for this module is the [`literal`] parser.
-
 use nom::{
     branch::alt,
     bytes::complete::tag,
     character::complete::{char, digit1},
     combinator::{map, map_opt, opt},
-    error::ParseError,
     sequence::pair,
-    IResult,
 };
 
-use crate::ast::{Literal, Span};
+use crate::{
+    ast::{Literal, Span},
+    parser::IResult,
+};
 
 /// Parses a [`Literal`](crate::ast::Literal).
 ///
 /// The only valid inputs for this parser are `"true"`, `"false"`, `"unit"` or a signed integer
 /// (which is parsed by the [`number`](number) parser).
-pub fn literal<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Literal, E> {
+pub fn literal(input: Span) -> IResult<Literal> {
     alt((
         map(tag("true"), |_| Literal::Bool(true)),
         map(tag("false"), |_| Literal::Bool(false)),
@@ -34,7 +34,7 @@ pub fn literal<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>
 ///
 /// If the number is negative, there cannot be spaces between the minus sign and the digits of the
 /// number. That kind of expression will be parsed as an unary operation.
-fn number<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, i128, E> {
+fn number(input: Span) -> IResult<i128> {
     map_opt(
         pair(opt(char('-')), digit1),
         |(sign, digits_span): (Option<char>, Span)| {

--- a/src/parser/literal.rs
+++ b/src/parser/literal.rs
@@ -18,6 +18,9 @@ use crate::{
 ///
 /// The only valid inputs for this parser are `"true"`, `"false"`, `"unit"` or a signed integer
 /// (which is parsed by the [`number`](number) parser).
+///
+/// The location of this element matches the start and end of the inputs mentioned above inside the
+/// source code.
 pub fn literal(input: Span) -> IResult<Located<Literal>> {
     alt((
         map(tag("true"), |span: Span| {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -26,7 +26,7 @@ use thiserror::Error;
 use nom::{character::complete::multispace0, combinator::all_consuming, error::ErrorKind, Err::*};
 
 use crate::{
-    ast::{Block, Location},
+    ast::{Block, Located, Location},
     LangResult,
 };
 
@@ -58,9 +58,9 @@ type IResult<'a, T> = nom::IResult<Span<'a>, T, (Span<'a>, ErrorKind)>;
 ///
 /// This function fails if the whole string is not consumed during parsing or if there is an error
 /// with the inner parsers.
-pub fn parse(input: &str) -> LangResult<Block> {
+pub fn parse(input: &str) -> LangResult<Located<Block>> {
     let span = Span::new(input);
-    let result: IResult<Block> = all_consuming(surrounded(block0, multispace0))(span);
+    let result: IResult<Located<Block>> = all_consuming(surrounded(block0, multispace0))(span);
     println!("{:#?}", result);
     match result {
         Ok((_, block)) => Ok(block),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -62,8 +62,8 @@ pub fn parse(input: &str) -> LangResult<Block> {
 }
 
 #[derive(Error, Debug)]
-#[error("Parser `{kind:?}` failed at span {span:?}")]
+#[error("Parsing rule `{kind:?}` failed.")]
 pub struct ParseError<'a> {
-    span: Span<'a>,
+    pub span: Span<'a>,
     kind: ErrorKind,
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -61,7 +61,6 @@ type IResult<'a, T> = nom::IResult<Span<'a>, T, (Span<'a>, ErrorKind)>;
 pub fn parse(input: &str) -> LangResult<Located<Block>> {
     let span = Span::new(input);
     let result: IResult<Located<Block>> = all_consuming(surrounded(block0, multispace0))(span);
-    println!("{:#?}", result);
     match result {
         Ok((_, block)) => Ok(block),
         Err(Error(e)) | Err(Failure(e)) => Err(ParseError {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -23,9 +23,7 @@
 //! [nom docs]: https://docs.rs/nom/
 use thiserror::Error;
 
-use nom::{
-    character::complete::multispace0, combinator::all_consuming, error::ErrorKind, Err::*, IResult,
-};
+use nom::{character::complete::multispace0, combinator::all_consuming, error::ErrorKind, Err::*};
 
 use crate::{
     ast::{Block, Span},
@@ -44,14 +42,15 @@ mod node;
 mod ty;
 mod un_op;
 
+type IResult<'a, T> = nom::IResult<Span<'a>, T, (Span<'a>, ErrorKind)>;
+
 /// Produces a [`Block`] from a string slice.
 ///
 /// This function fails if the whole string is not consumed during parsing or if there is an error
 /// with the inner parsers.
-pub fn parse<'a>(input: &'a str) -> LangResult<Block<'a>> {
+pub fn parse(input: &str) -> LangResult<Block> {
     let span = Span::new(input);
-    let result: IResult<Span, Block, (Span<'a>, ErrorKind)> =
-        all_consuming(surrounded(block0, multispace0))(span);
+    let result: IResult<Block> = all_consuming(surrounded(block0, multispace0))(span);
     match result {
         Ok((_, block)) => Ok(block),
         Err(Error(e)) | Err(Failure(e)) => Err(ParseError {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -51,6 +51,7 @@ type IResult<'a, T> = nom::IResult<Span<'a>, T, (Span<'a>, ErrorKind)>;
 pub fn parse(input: &str) -> LangResult<Block> {
     let span = Span::new(input);
     let result: IResult<Block> = all_consuming(surrounded(block0, multispace0))(span);
+    println!("{:#?}", result);
     match result {
         Ok((_, block)) => Ok(block),
         Err(Error(e)) | Err(Failure(e)) => Err(ParseError {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -26,7 +26,7 @@ use thiserror::Error;
 use nom::{character::complete::multispace0, combinator::all_consuming, error::ErrorKind, Err::*};
 
 use crate::{
-    ast::{Block, Span},
+    ast::{Block, Location},
     LangResult,
 };
 
@@ -41,6 +41,16 @@ mod name;
 mod node;
 mod ty;
 mod un_op;
+
+type Span<'a> = nom_locate::LocatedSpan<&'a str>;
+
+impl<'a> From<Span<'a>> for Location {
+    fn from(span: Span<'a>) -> Self {
+        let start = span.location_offset();
+        let end = start + span.fragment().len();
+        Location { start, end }
+    }
+}
 
 type IResult<'a, T> = nom::IResult<Span<'a>, T, (Span<'a>, ErrorKind)>;
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -22,14 +22,13 @@
 //! [ABNF]: https://en.wikipedia.org/wiki/Augmented_Backus–Naur_form
 //! [nom docs]: https://docs.rs/nom/
 use nom::{
-    character::complete::multispace0,
-    combinator::all_consuming,
-    error::{convert_error, VerboseError},
-    Err::{Error, Failure},
-    IResult,
+    character::complete::multispace0, combinator::all_consuming, error::VerboseError, IResult,
 };
 
-use crate::{ast::Block, LangError, LangResult};
+use crate::{
+    ast::{Block, Span},
+    LangError, LangResult,
+};
 
 use block::block0;
 use helpers::surrounded;
@@ -48,11 +47,12 @@ mod un_op;
 /// This function fails if the whole string is not consumed during parsing or if there is an error
 /// with the inner parsers.
 pub fn parse<'a>(input: &'a str) -> LangResult<Block<'a>> {
-    let result: IResult<&str, Block, VerboseError<&str>> =
-        all_consuming(surrounded(block0, multispace0))(input);
+    let span = Span::new(input);
+    let result: IResult<Span, Block, VerboseError<Span<'a>>> =
+        all_consuming(surrounded(block0, multispace0))(span);
     match result {
         Ok((_, block)) => Ok(block),
-        Err(Error(e)) | Err(Failure(e)) => Err(LangError::Parse(convert_error(input, e))),
+        // Err(Error(e)) | Err(Failure(e)) => Err(LangError::Parse(convert_error(input, e))),
         _ => Err(LangError::Parse(String::new())),
     }
 }

--- a/src/parser/name.rs
+++ b/src/parser/name.rs
@@ -6,12 +6,13 @@
 use nom::{
     character::complete::{alpha1, char},
     combinator::{map, recognize, verify},
-    error::ParseError,
     multi::separated_nonempty_list,
-    IResult,
 };
 
-use crate::ast::{Name, Span};
+use crate::{
+    ast::{Name, Span},
+    parser::IResult,
+};
 
 /// Words that cannot be names to avoid ambiguities.
 const KEYWORDS: &[&str] = &[
@@ -23,11 +24,11 @@ const KEYWORDS: &[&str] = &[
 /// This parser is the main reason why most of the types and functions in the language are generic
 /// over the `'a` lifetime. It allows to do zero-copy parsing and keep using the string slices
 /// for the names through all the compilation process.
-pub fn name<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Name<'a>, E> {
+pub fn name(input: Span) -> IResult<Name> {
     verify(
         map(
             recognize(separated_nonempty_list(char('_'), alpha1)),
-            |span: Span<'a>| Name(span.fragment()),
+            |span: Span| Name(span.fragment()),
         ),
         |Name(s)| !KEYWORDS.contains(s),
     )(input)

--- a/src/parser/name.rs
+++ b/src/parser/name.rs
@@ -1,7 +1,7 @@
 //! Parsers for names.
 //!
 //! The entry point for this module is the [`name`] function. Names of variables in Pijama must be
-//! alphabetic `snake-case` strings. Certain keywords such as `fn`, `do` and `end` cannot be names,
+//! alphabetic `snake_case` strings. Certain keywords such as `fn`, `do` and `end` cannot be names,
 //! such keywords are in the [`KEYWORDS`] constant.
 use nom::{
     character::complete::{alpha1, char},
@@ -24,6 +24,8 @@ const KEYWORDS: &[&str] = &[
 /// This parser is the main reason why most of the types and functions in the language are generic
 /// over the `'a` lifetime. It allows to do zero-copy parsing and keep using the string slices
 /// for the names through all the compilation process.
+///
+/// The location of this element matches the start and end of its string slice in the source code.
 pub fn name(input: Span) -> IResult<Located<Name>> {
     verify(
         map(

--- a/src/parser/name.rs
+++ b/src/parser/name.rs
@@ -10,8 +10,8 @@ use nom::{
 };
 
 use crate::{
-    ast::{Located, Name, Span},
-    parser::IResult,
+    ast::{Located, Name},
+    parser::{IResult, Span},
 };
 
 /// Words that cannot be names to avoid ambiguities.
@@ -28,7 +28,7 @@ pub fn name(input: Span) -> IResult<Located<Name>> {
     verify(
         map(
             recognize(separated_nonempty_list(char('_'), alpha1)),
-            |span: Span| Located::new(Name(span.fragment()), span.into()),
+            |span: Span| Located::new(Name(span.fragment()), span),
         ),
         |name| !KEYWORDS.contains(&name.content.0),
     )(input)

--- a/src/parser/name.rs
+++ b/src/parser/name.rs
@@ -10,7 +10,7 @@ use nom::{
 };
 
 use crate::{
-    ast::{Name, Span},
+    ast::{Located, Name, Span},
     parser::IResult,
 };
 
@@ -24,12 +24,12 @@ const KEYWORDS: &[&str] = &[
 /// This parser is the main reason why most of the types and functions in the language are generic
 /// over the `'a` lifetime. It allows to do zero-copy parsing and keep using the string slices
 /// for the names through all the compilation process.
-pub fn name(input: Span) -> IResult<Name> {
+pub fn name(input: Span) -> IResult<Located<Name>> {
     verify(
         map(
             recognize(separated_nonempty_list(char('_'), alpha1)),
-            |span: Span| Name(span.fragment()),
+            |span: Span| Located::new(Name(span.fragment()), span.into()),
         ),
-        |Name(s)| !KEYWORDS.contains(s),
+        |name| !KEYWORDS.contains(&name.content.0),
     )(input)
 }

--- a/src/parser/name.rs
+++ b/src/parser/name.rs
@@ -11,7 +11,7 @@ use nom::{
     IResult,
 };
 
-use crate::ast::Name;
+use crate::ast::{Name, Span};
 
 /// Words that cannot be names to avoid ambiguities.
 const KEYWORDS: &[&str] = &[
@@ -23,11 +23,12 @@ const KEYWORDS: &[&str] = &[
 /// This parser is the main reason why most of the types and functions in the language are generic
 /// over the `'a` lifetime. It allows to do zero-copy parsing and keep using the string slices
 /// for the names through all the compilation process.
-pub fn name<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Name<'a>, E> {
-    map(
-        verify(recognize(separated_nonempty_list(char('_'), alpha1)), |s| {
-            !KEYWORDS.contains(s)
-        }),
-        Name,
+pub fn name<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Name<'a>, E> {
+    verify(
+        map(
+            recognize(separated_nonempty_list(char('_'), alpha1)),
+            |span: Span<'a>| Name(span.fragment()),
+        ),
+        |Name(s)| !KEYWORDS.contains(s),
     )(input)
 }

--- a/src/parser/node/binary_op.rs
+++ b/src/parser/node/binary_op.rs
@@ -41,9 +41,8 @@
 //! [`bin_op`]: crate::parser::bin_op
 use nom::{
     combinator::{cut, opt},
-    sequence::tuple,
+    sequence::pair,
 };
-use nom_locate::position;
 
 use crate::{
     ast::{Node, NodeKind, Span},
@@ -53,70 +52,50 @@ use crate::{
 /// Parses a [`Node::BinaryOp`].
 pub fn binary_op(input: Span) -> IResult<Node> {
     let (mut input, mut node) = binary_op_1(input)?;
-    while let (rem, Some((span, op, node2))) =
-        opt(tuple((position, bin_op_1, cut(binary_op_1))))(input)?
-    {
+    while let (rem, Some((op, node2))) = opt(pair(bin_op_1, cut(binary_op_1)))(input)? {
         input = rem;
-        node = Node {
-            span,
-            kind: NodeKind::BinaryOp(op, Box::new(node), Box::new(node2)),
-        };
+        let loc = node.loc + node2.loc;
+        node = Node::new(NodeKind::BinaryOp(op, Box::new(node), Box::new(node2)), loc);
     }
     Ok((input, node))
 }
 
 fn binary_op_1(input: Span) -> IResult<Node> {
     let (mut input, mut node) = binary_op_2(input)?;
-    while let (rem, Some((span, op, node2))) =
-        opt(tuple((position, bin_op_2, cut(binary_op_2))))(input)?
-    {
+    while let (rem, Some((op, node2))) = opt(pair(bin_op_2, cut(binary_op_2)))(input)? {
         input = rem;
-        node = Node {
-            span,
-            kind: NodeKind::BinaryOp(op, Box::new(node), Box::new(node2)),
-        };
+        let loc = node.loc + node2.loc;
+        node = Node::new(NodeKind::BinaryOp(op, Box::new(node), Box::new(node2)), loc);
     }
     Ok((input, node))
 }
 
 fn binary_op_2(input: Span) -> IResult<Node> {
     let (mut input, mut node) = binary_op_3(input)?;
-    while let (rem, Some((span, op, node2))) =
-        opt(tuple((position, bin_op_3, cut(binary_op_3))))(input)?
-    {
+    while let (rem, Some((op, node2))) = opt(pair(bin_op_3, cut(binary_op_3)))(input)? {
         input = rem;
-        node = Node {
-            span,
-            kind: NodeKind::BinaryOp(op, Box::new(node), Box::new(node2)),
-        };
+        let loc = node.loc + node2.loc;
+        node = Node::new(NodeKind::BinaryOp(op, Box::new(node), Box::new(node2)), loc);
     }
     Ok((input, node))
 }
 
 fn binary_op_3(input: Span) -> IResult<Node> {
     let (mut input, mut node) = binary_op_4(input)?;
-    while let (rem, Some((span, op, node2))) =
-        opt(tuple((position, bin_op_4, cut(binary_op_4))))(input)?
-    {
+    while let (rem, Some((op, node2))) = opt(pair(bin_op_4, cut(binary_op_4)))(input)? {
         input = rem;
-        node = Node {
-            span,
-            kind: NodeKind::BinaryOp(op, Box::new(node), Box::new(node2)),
-        };
+        let loc = node.loc + node2.loc;
+        node = Node::new(NodeKind::BinaryOp(op, Box::new(node), Box::new(node2)), loc);
     }
     Ok((input, node))
 }
 
 fn binary_op_4(input: Span) -> IResult<Node> {
     let (mut input, mut node) = base_node(input)?;
-    while let (rem, Some((span, op, node2))) =
-        opt(tuple((position, bin_op_5, cut(base_node))))(input)?
-    {
+    while let (rem, Some((op, node2))) = opt(pair(bin_op_5, cut(base_node)))(input)? {
         input = rem;
-        node = Node {
-            span,
-            kind: NodeKind::BinaryOp(op, Box::new(node), Box::new(node2)),
-        };
+        let loc = node.loc + node2.loc;
+        node = Node::new(NodeKind::BinaryOp(op, Box::new(node), Box::new(node2)), loc);
     }
     Ok((input, node))
 }

--- a/src/parser/node/binary_op.rs
+++ b/src/parser/node/binary_op.rs
@@ -41,19 +41,17 @@
 //! [`bin_op`]: crate::parser::bin_op
 use nom::{
     combinator::{cut, opt},
-    error::ParseError,
     sequence::tuple,
-    IResult,
 };
 use nom_locate::position;
 
 use crate::{
     ast::{Node, NodeKind, Span},
-    parser::{bin_op::*, node::base_node},
+    parser::{bin_op::*, node::base_node, IResult},
 };
 
 /// Parses a [`Node::BinaryOp`].
-pub fn binary_op<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Node, E> {
+pub fn binary_op(input: Span) -> IResult<Node> {
     let (mut input, mut node) = binary_op_1(input)?;
     while let (rem, Some((span, op, node2))) =
         opt(tuple((position, bin_op_1, cut(binary_op_1))))(input)?
@@ -67,7 +65,7 @@ pub fn binary_op<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'
     Ok((input, node))
 }
 
-fn binary_op_1<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Node, E> {
+fn binary_op_1(input: Span) -> IResult<Node> {
     let (mut input, mut node) = binary_op_2(input)?;
     while let (rem, Some((span, op, node2))) =
         opt(tuple((position, bin_op_2, cut(binary_op_2))))(input)?
@@ -81,7 +79,7 @@ fn binary_op_1<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>
     Ok((input, node))
 }
 
-fn binary_op_2<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Node, E> {
+fn binary_op_2(input: Span) -> IResult<Node> {
     let (mut input, mut node) = binary_op_3(input)?;
     while let (rem, Some((span, op, node2))) =
         opt(tuple((position, bin_op_3, cut(binary_op_3))))(input)?
@@ -95,7 +93,7 @@ fn binary_op_2<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>
     Ok((input, node))
 }
 
-fn binary_op_3<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Node, E> {
+fn binary_op_3(input: Span) -> IResult<Node> {
     let (mut input, mut node) = binary_op_4(input)?;
     while let (rem, Some((span, op, node2))) =
         opt(tuple((position, bin_op_4, cut(binary_op_4))))(input)?
@@ -109,7 +107,7 @@ fn binary_op_3<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>
     Ok((input, node))
 }
 
-fn binary_op_4<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Node, E> {
+fn binary_op_4(input: Span) -> IResult<Node> {
     let (mut input, mut node) = base_node(input)?;
     while let (rem, Some((span, op, node2))) =
         opt(tuple((position, bin_op_5, cut(base_node))))(input)?

--- a/src/parser/node/binary_op.rs
+++ b/src/parser/node/binary_op.rs
@@ -45,57 +45,57 @@ use nom::{
 };
 
 use crate::{
-    ast::{Node, NodeKind},
+    ast::{Located, Node},
     parser::{bin_op::*, node::base_node, IResult, Span},
 };
 
 /// Parses a [`Node::BinaryOp`].
-pub fn binary_op(input: Span) -> IResult<Node> {
+pub fn binary_op(input: Span) -> IResult<Located<Node>> {
     let (mut input, mut node) = binary_op_1(input)?;
     while let (rem, Some((op, node2))) = opt(pair(bin_op_1, cut(binary_op_1)))(input)? {
         input = rem;
         let loc = node.loc + node2.loc;
-        node = Node::new(NodeKind::BinaryOp(op, Box::new(node), Box::new(node2)), loc);
+        node = Located::new(Node::BinaryOp(op, Box::new(node), Box::new(node2)), loc);
     }
     Ok((input, node))
 }
 
-fn binary_op_1(input: Span) -> IResult<Node> {
+fn binary_op_1(input: Span) -> IResult<Located<Node>> {
     let (mut input, mut node) = binary_op_2(input)?;
     while let (rem, Some((op, node2))) = opt(pair(bin_op_2, cut(binary_op_2)))(input)? {
         input = rem;
         let loc = node.loc + node2.loc;
-        node = Node::new(NodeKind::BinaryOp(op, Box::new(node), Box::new(node2)), loc);
+        node = Located::new(Node::BinaryOp(op, Box::new(node), Box::new(node2)), loc);
     }
     Ok((input, node))
 }
 
-fn binary_op_2(input: Span) -> IResult<Node> {
+fn binary_op_2(input: Span) -> IResult<Located<Node>> {
     let (mut input, mut node) = binary_op_3(input)?;
     while let (rem, Some((op, node2))) = opt(pair(bin_op_3, cut(binary_op_3)))(input)? {
         input = rem;
         let loc = node.loc + node2.loc;
-        node = Node::new(NodeKind::BinaryOp(op, Box::new(node), Box::new(node2)), loc);
+        node = Located::new(Node::BinaryOp(op, Box::new(node), Box::new(node2)), loc);
     }
     Ok((input, node))
 }
 
-fn binary_op_3(input: Span) -> IResult<Node> {
+fn binary_op_3(input: Span) -> IResult<Located<Node>> {
     let (mut input, mut node) = binary_op_4(input)?;
     while let (rem, Some((op, node2))) = opt(pair(bin_op_4, cut(binary_op_4)))(input)? {
         input = rem;
         let loc = node.loc + node2.loc;
-        node = Node::new(NodeKind::BinaryOp(op, Box::new(node), Box::new(node2)), loc);
+        node = Located::new(Node::BinaryOp(op, Box::new(node), Box::new(node2)), loc);
     }
     Ok((input, node))
 }
 
-fn binary_op_4(input: Span) -> IResult<Node> {
+fn binary_op_4(input: Span) -> IResult<Located<Node>> {
     let (mut input, mut node) = base_node(input)?;
     while let (rem, Some((op, node2))) = opt(pair(bin_op_5, cut(base_node)))(input)? {
         input = rem;
         let loc = node.loc + node2.loc;
-        node = Node::new(NodeKind::BinaryOp(op, Box::new(node), Box::new(node2)), loc);
+        node = Located::new(Node::BinaryOp(op, Box::new(node), Box::new(node2)), loc);
     }
     Ok((input, node))
 }

--- a/src/parser/node/binary_op.rs
+++ b/src/parser/node/binary_op.rs
@@ -36,6 +36,9 @@
 //! Every binary operator here is considered to be left-associative, in contrast with the `->` for
 //! in the [`ty`] module which is right-associative.
 //!
+//! The location of the returned binary operations matches the start of the first operand and the
+//! end of the second.
+//!
 //! [`ty`]: crate::parser::ty
 //! [`node`]: crate::parser::node::node
 //! [`bin_op`]: crate::parser::bin_op

--- a/src/parser/node/binary_op.rs
+++ b/src/parser/node/binary_op.rs
@@ -42,57 +42,83 @@
 use nom::{
     combinator::{cut, opt},
     error::ParseError,
-    sequence::pair,
+    sequence::tuple,
     IResult,
 };
+use nom_locate::position;
 
 use crate::{
-    ast::Node,
+    ast::{Node, NodeKind, Span},
     parser::{bin_op::*, node::base_node},
 };
 
 /// Parses a [`Node::BinaryOp`].
-pub fn binary_op<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Node, E> {
+pub fn binary_op<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Node, E> {
     let (mut input, mut node) = binary_op_1(input)?;
-    while let (rem, Some((op, node2))) = opt(pair(bin_op_1, cut(binary_op_1)))(input)? {
+    while let (rem, Some((span, op, node2))) =
+        opt(tuple((position, bin_op_1, cut(binary_op_1))))(input)?
+    {
         input = rem;
-        node = Node::BinaryOp(op, Box::new(node), Box::new(node2));
+        node = Node {
+            span,
+            kind: NodeKind::BinaryOp(op, Box::new(node), Box::new(node2)),
+        };
     }
     Ok((input, node))
 }
 
-fn binary_op_1<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Node, E> {
+fn binary_op_1<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Node, E> {
     let (mut input, mut node) = binary_op_2(input)?;
-    while let (rem, Some((op, node2))) = opt(pair(bin_op_2, cut(binary_op_2)))(input)? {
+    while let (rem, Some((span, op, node2))) =
+        opt(tuple((position, bin_op_2, cut(binary_op_2))))(input)?
+    {
         input = rem;
-        node = Node::BinaryOp(op, Box::new(node), Box::new(node2));
+        node = Node {
+            span,
+            kind: NodeKind::BinaryOp(op, Box::new(node), Box::new(node2)),
+        };
     }
     Ok((input, node))
 }
 
-fn binary_op_2<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Node, E> {
+fn binary_op_2<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Node, E> {
     let (mut input, mut node) = binary_op_3(input)?;
-    while let (rem, Some((op, node2))) = opt(pair(bin_op_3, cut(binary_op_3)))(input)? {
+    while let (rem, Some((span, op, node2))) =
+        opt(tuple((position, bin_op_3, cut(binary_op_3))))(input)?
+    {
         input = rem;
-        node = Node::BinaryOp(op, Box::new(node), Box::new(node2));
+        node = Node {
+            span,
+            kind: NodeKind::BinaryOp(op, Box::new(node), Box::new(node2)),
+        };
     }
     Ok((input, node))
 }
 
-fn binary_op_3<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Node, E> {
+fn binary_op_3<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Node, E> {
     let (mut input, mut node) = binary_op_4(input)?;
-    while let (rem, Some((op, node2))) = opt(pair(bin_op_4, cut(binary_op_4)))(input)? {
+    while let (rem, Some((span, op, node2))) =
+        opt(tuple((position, bin_op_4, cut(binary_op_4))))(input)?
+    {
         input = rem;
-        node = Node::BinaryOp(op, Box::new(node), Box::new(node2));
+        node = Node {
+            span,
+            kind: NodeKind::BinaryOp(op, Box::new(node), Box::new(node2)),
+        };
     }
     Ok((input, node))
 }
 
-fn binary_op_4<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Node, E> {
+fn binary_op_4<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Node, E> {
     let (mut input, mut node) = base_node(input)?;
-    while let (rem, Some((op, node2))) = opt(pair(bin_op_5, cut(base_node)))(input)? {
+    while let (rem, Some((span, op, node2))) =
+        opt(tuple((position, bin_op_5, cut(base_node))))(input)?
+    {
         input = rem;
-        node = Node::BinaryOp(op, Box::new(node), Box::new(node2));
+        node = Node {
+            span,
+            kind: NodeKind::BinaryOp(op, Box::new(node), Box::new(node2)),
+        };
     }
     Ok((input, node))
 }

--- a/src/parser/node/binary_op.rs
+++ b/src/parser/node/binary_op.rs
@@ -45,8 +45,8 @@ use nom::{
 };
 
 use crate::{
-    ast::{Node, NodeKind, Span},
-    parser::{bin_op::*, node::base_node, IResult},
+    ast::{Node, NodeKind},
+    parser::{bin_op::*, node::base_node, IResult, Span},
 };
 
 /// Parses a [`Node::BinaryOp`].

--- a/src/parser/node/call.rs
+++ b/src/parser/node/call.rs
@@ -9,7 +9,7 @@
 use nom::{character::complete::space0, combinator::map, sequence::separated_pair};
 
 use crate::{
-    ast::{Node, NodeKind},
+    ast::{Located, Node},
     parser::{
         name::name,
         node::{fn_def::args, node},
@@ -22,9 +22,9 @@ use crate::{
 /// This parser admits:
 /// - Spaces after the name of the function.
 /// - Spaces before and spaces or line breaks after each comma.
-pub fn call(input: Span) -> IResult<Node> {
+pub fn call(input: Span) -> IResult<Located<Node>> {
     map(separated_pair(name, space0, args(node)), |(name, args)| {
         let loc = name.loc + args.loc;
-        Node::new(NodeKind::Call(name, args.content), loc)
+        Located::new(Node::Call(name, args.content), loc)
     })(input)
 }

--- a/src/parser/node/call.rs
+++ b/src/parser/node/call.rs
@@ -22,6 +22,9 @@ use crate::{
 /// This parser admits:
 /// - Spaces after the name of the function.
 /// - Spaces before and spaces or line breaks after each comma.
+///
+/// The location of the returned node matches the start of the name and the end of the node after
+/// the `=`.
 pub fn call(input: Span) -> IResult<Located<Node>> {
     map(separated_pair(name, space0, args(node)), |(name, args)| {
         let loc = name.loc + args.loc;

--- a/src/parser/node/call.rs
+++ b/src/parser/node/call.rs
@@ -7,7 +7,6 @@
 //! call = "name "(" (node ("," node)*)? ")"
 //! ```
 use nom::{character::complete::space0, combinator::map, sequence::separated_pair};
-use nom_locate::position;
 
 use crate::{
     ast::{Node, NodeKind, Span},
@@ -24,12 +23,8 @@ use crate::{
 /// - Spaces after the name of the function.
 /// - Spaces before and spaces or line breaks after each comma.
 pub fn call(input: Span) -> IResult<Node> {
-    let (input, span) = position(input)?;
-    map(
-        separated_pair(name, space0, args(node)),
-        move |(name, args)| Node {
-            kind: NodeKind::Call(name, args),
-            span,
-        },
-    )(input)
+    map(separated_pair(name, space0, args(node)), |(name, args)| {
+        let loc = name.loc + args.loc;
+        Node::new(NodeKind::Call(name, args.content), loc)
+    })(input)
 }

--- a/src/parser/node/call.rs
+++ b/src/parser/node/call.rs
@@ -6,10 +6,7 @@
 //! ```abnf
 //! call = "name "(" (node ("," node)*)? ")"
 //! ```
-use nom::{
-    character::complete::space0, combinator::map, error::ParseError, sequence::separated_pair,
-    IResult,
-};
+use nom::{character::complete::space0, combinator::map, sequence::separated_pair};
 use nom_locate::position;
 
 use crate::{
@@ -17,6 +14,7 @@ use crate::{
     parser::{
         name::name,
         node::{fn_def::args, node},
+        IResult,
     },
 };
 
@@ -25,7 +23,7 @@ use crate::{
 /// This parser admits:
 /// - Spaces after the name of the function.
 /// - Spaces before and spaces or line breaks after each comma.
-pub fn call<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Node, E> {
+pub fn call(input: Span) -> IResult<Node> {
     let (input, span) = position(input)?;
     map(
         separated_pair(name, space0, args(node)),

--- a/src/parser/node/call.rs
+++ b/src/parser/node/call.rs
@@ -9,11 +9,11 @@
 use nom::{character::complete::space0, combinator::map, sequence::separated_pair};
 
 use crate::{
-    ast::{Node, NodeKind, Span},
+    ast::{Node, NodeKind},
     parser::{
         name::name,
         node::{fn_def::args, node},
-        IResult,
+        IResult, Span,
     },
 };
 

--- a/src/parser/node/call.rs
+++ b/src/parser/node/call.rs
@@ -10,9 +10,10 @@ use nom::{
     character::complete::space0, combinator::map, error::ParseError, sequence::separated_pair,
     IResult,
 };
+use nom_locate::position;
 
 use crate::{
-    ast::Node,
+    ast::{Node, NodeKind, Span},
     parser::{
         name::name,
         node::{fn_def::args, node},
@@ -24,8 +25,13 @@ use crate::{
 /// This parser admits:
 /// - Spaces after the name of the function.
 /// - Spaces before and spaces or line breaks after each comma.
-pub fn call<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Node, E> {
-    map(separated_pair(name, space0, args(node)), |(name, args)| {
-        Node::Call(name, args)
-    })(input)
+pub fn call<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Node, E> {
+    let (input, span) = position(input)?;
+    map(
+        separated_pair(name, space0, args(node)),
+        move |(name, args)| Node {
+            kind: NodeKind::Call(name, args),
+            span,
+        },
+    )(input)
 }

--- a/src/parser/node/cond.rs
+++ b/src/parser/node/cond.rs
@@ -25,6 +25,8 @@ use crate::{
 /// Parses a [`Node::Cond`].
 ///
 /// The spacing is explained in the other parsers of this module.
+///
+/// The location of the returned node matches the start of the `if` and the end of the `end`.
 pub fn cond(input: Span) -> IResult<Located<Node>> {
     map(
         tuple((
@@ -48,6 +50,8 @@ pub fn cond(input: Span) -> IResult<Located<Node>> {
 ///
 /// There must be at least one space or line break between the `if` and the first node in the
 /// block. There can be spaces or line breaks at the end of the block.
+///
+/// The location of the returned block ignores the `if` and spaces surrounding the block.
 fn if_block(input: Span) -> IResult<Located<Block>> {
     delimited(pair(tag("if"), multispace1), block1, multispace0)(input)
 }
@@ -56,6 +60,8 @@ fn if_block(input: Span) -> IResult<Located<Block>> {
 ///
 /// There must be at least one space or line break between the `do` and the first node in the
 /// block. There can be spaces or line breaks at the end of the block.
+///
+/// The location of the returned block ignores the `do` and spaces surrounding the block.
 fn do_block(input: Span) -> IResult<Located<Block>> {
     delimited(pair(tag("do"), multispace1), block1, multispace0)(input)
 }
@@ -64,6 +70,8 @@ fn do_block(input: Span) -> IResult<Located<Block>> {
 ///
 /// There must be at least one space or line break between the `else` and the first node in the
 /// block. There can be spaces or line breaks at the end of the block.
+///
+/// The location of the returned block ignores the `else` and spaces surrounding the block.
 fn else_block(input: Span) -> IResult<Located<Block>> {
     delimited(pair(tag("else"), multispace1), block1, multispace0)(input)
 }

--- a/src/parser/node/cond.rs
+++ b/src/parser/node/cond.rs
@@ -8,7 +8,7 @@
 //! ```
 //!
 //! Thus, `else` blocks are optional and are represented as empty [`Block`]s inside the
-//! [`Node::Cond`] variant.
+//! [`Located::Cond`] variant.
 use nom::{
     bytes::complete::tag,
     character::complete::{multispace0, multispace1},
@@ -18,14 +18,14 @@ use nom::{
 use nom_locate::position;
 
 use crate::{
-    ast::{Block, Location, Node, NodeKind},
+    ast::{Block, Located, Location, Node},
     parser::{block::block1, IResult, Span},
 };
 
-/// Parses a [`Node::Cond`].
+/// Parses a [`Located::Cond`].
 ///
 /// The spacing is explained in the other parsers of this module.
-pub fn cond(input: Span) -> IResult<Node> {
+pub fn cond(input: Span) -> IResult<Located<Node>> {
     map(
         tuple((
             position,
@@ -35,15 +35,15 @@ pub fn cond(input: Span) -> IResult<Node> {
             preceded(tag("end"), position),
         )),
         move |(sp1, if_block, do_block, else_block, sp2)| {
-            Node::new(
-                NodeKind::Cond(if_block, do_block, else_block.unwrap_or_default()),
+            Located::new(
+                Node::Cond(if_block, do_block, else_block.unwrap_or_default()),
                 Location::from(sp1) + Location::from(sp2),
             )
         },
     )(input)
 }
 
-/// Parses the `if` block of a [`Node::Cond`].
+/// Parses the `if` block of a [`Located::Cond`].
 ///
 /// There must be at least one space or line break between the `if` and the first node in the
 /// block. There can be spaces or line breaks at the end of the block.
@@ -51,7 +51,7 @@ fn if_block(input: Span) -> IResult<Block> {
     delimited(pair(tag("if"), multispace1), block1, multispace0)(input)
 }
 
-/// Parses the `do` block of a [`Node::Cond`].
+/// Parses the `do` block of a [`Located::Cond`].
 ///
 /// There must be at least one space or line break between the `do` and the first node in the
 /// block. There can be spaces or line breaks at the end of the block.
@@ -59,7 +59,7 @@ fn do_block(input: Span) -> IResult<Block> {
     delimited(pair(tag("do"), multispace1), block1, multispace0)(input)
 }
 
-/// Parses the `else` block of a [`Node::Cond`].
+/// Parses the `else` block of a [`Located::Cond`].
 ///
 /// There must be at least one space or line break between the `else` and the first node in the
 /// block. There can be spaces or line breaks at the end of the block.

--- a/src/parser/node/cond.rs
+++ b/src/parser/node/cond.rs
@@ -13,21 +13,19 @@ use nom::{
     bytes::complete::tag,
     character::complete::{multispace0, multispace1},
     combinator::{map, opt},
-    error::ParseError,
     sequence::{delimited, pair, terminated, tuple},
-    IResult,
 };
 use nom_locate::position;
 
 use crate::{
     ast::{Block, Node, NodeKind, Span},
-    parser::block::block1,
+    parser::{block::block1, IResult},
 };
 
 /// Parses a [`Node::Cond`].
 ///
 /// The spacing is explained in the other parsers of this module.
-pub fn cond<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Node, E> {
+pub fn cond(input: Span) -> IResult<Node> {
     let (input, span) = position(input)?;
     map(
         terminated(tuple((if_block, do_block, opt(else_block))), tag("end")),
@@ -42,7 +40,7 @@ pub fn cond<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, N
 ///
 /// There must be at least one space or line break between the `if` and the first node in the
 /// block. There can be spaces or line breaks at the end of the block.
-fn if_block<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Block, E> {
+fn if_block(input: Span) -> IResult<Block> {
     delimited(pair(tag("if"), multispace1), block1, multispace0)(input)
 }
 
@@ -50,7 +48,7 @@ fn if_block<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, B
 ///
 /// There must be at least one space or line break between the `do` and the first node in the
 /// block. There can be spaces or line breaks at the end of the block.
-fn do_block<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Block, E> {
+fn do_block(input: Span) -> IResult<Block> {
     delimited(pair(tag("do"), multispace1), block1, multispace0)(input)
 }
 
@@ -58,6 +56,6 @@ fn do_block<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, B
 ///
 /// There must be at least one space or line break between the `else` and the first node in the
 /// block. There can be spaces or line breaks at the end of the block.
-fn else_block<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Block, E> {
+fn else_block(input: Span) -> IResult<Block> {
     delimited(pair(tag("else"), multispace1), block1, multispace0)(input)
 }

--- a/src/parser/node/cond.rs
+++ b/src/parser/node/cond.rs
@@ -18,8 +18,8 @@ use nom::{
 use nom_locate::position;
 
 use crate::{
-    ast::{Block, Location, Node, NodeKind, Span},
-    parser::{block::block1, IResult},
+    ast::{Block, Location, Node, NodeKind},
+    parser::{block::block1, IResult, Span},
 };
 
 /// Parses a [`Node::Cond`].

--- a/src/parser/node/cond.rs
+++ b/src/parser/node/cond.rs
@@ -8,7 +8,7 @@
 //! ```
 //!
 //! Thus, `else` blocks are optional and are represented as empty [`Block`]s inside the
-//! [`Located::Cond`] variant.
+//! [`Node::Cond`] variant.
 use nom::{
     bytes::complete::tag,
     character::complete::{multispace0, multispace1},
@@ -22,7 +22,7 @@ use crate::{
     parser::{block::block1, IResult, Span},
 };
 
-/// Parses a [`Located::Cond`].
+/// Parses a [`Node::Cond`].
 ///
 /// The spacing is explained in the other parsers of this module.
 pub fn cond(input: Span) -> IResult<Located<Node>> {
@@ -44,7 +44,7 @@ pub fn cond(input: Span) -> IResult<Located<Node>> {
     )(input)
 }
 
-/// Parses the `if` block of a [`Located::Cond`].
+/// Parses the `if` block of a [`Node::Cond`].
 ///
 /// There must be at least one space or line break between the `if` and the first node in the
 /// block. There can be spaces or line breaks at the end of the block.
@@ -52,7 +52,7 @@ fn if_block(input: Span) -> IResult<Located<Block>> {
     delimited(pair(tag("if"), multispace1), block1, multispace0)(input)
 }
 
-/// Parses the `do` block of a [`Located::Cond`].
+/// Parses the `do` block of a [`Node::Cond`].
 ///
 /// There must be at least one space or line break between the `do` and the first node in the
 /// block. There can be spaces or line breaks at the end of the block.
@@ -60,7 +60,7 @@ fn do_block(input: Span) -> IResult<Located<Block>> {
     delimited(pair(tag("do"), multispace1), block1, multispace0)(input)
 }
 
-/// Parses the `else` block of a [`Located::Cond`].
+/// Parses the `else` block of a [`Node::Cond`].
 ///
 /// There must be at least one space or line break between the `else` and the first node in the
 /// block. There can be spaces or line breaks at the end of the block.

--- a/src/parser/node/cond.rs
+++ b/src/parser/node/cond.rs
@@ -12,7 +12,7 @@
 use nom::{
     bytes::complete::tag,
     character::complete::{multispace0, multispace1},
-    combinator::{map, opt},
+    combinator::map,
     sequence::{delimited, pair, preceded, tuple},
 };
 use nom_locate::position;
@@ -31,12 +31,13 @@ pub fn cond(input: Span) -> IResult<Located<Node>> {
             position,
             if_block,
             do_block,
-            opt(else_block),
+            // FIXME: fix optional else block
+            else_block,
             preceded(tag("end"), position),
         )),
         move |(sp1, if_block, do_block, else_block, sp2)| {
             Located::new(
-                Node::Cond(if_block, do_block, else_block.unwrap_or_default()),
+                Node::Cond(if_block, do_block, else_block),
                 Location::from(sp1) + Location::from(sp2),
             )
         },
@@ -47,7 +48,7 @@ pub fn cond(input: Span) -> IResult<Located<Node>> {
 ///
 /// There must be at least one space or line break between the `if` and the first node in the
 /// block. There can be spaces or line breaks at the end of the block.
-fn if_block(input: Span) -> IResult<Block> {
+fn if_block(input: Span) -> IResult<Located<Block>> {
     delimited(pair(tag("if"), multispace1), block1, multispace0)(input)
 }
 
@@ -55,7 +56,7 @@ fn if_block(input: Span) -> IResult<Block> {
 ///
 /// There must be at least one space or line break between the `do` and the first node in the
 /// block. There can be spaces or line breaks at the end of the block.
-fn do_block(input: Span) -> IResult<Block> {
+fn do_block(input: Span) -> IResult<Located<Block>> {
     delimited(pair(tag("do"), multispace1), block1, multispace0)(input)
 }
 
@@ -63,6 +64,6 @@ fn do_block(input: Span) -> IResult<Block> {
 ///
 /// There must be at least one space or line break between the `else` and the first node in the
 /// block. There can be spaces or line breaks at the end of the block.
-fn else_block(input: Span) -> IResult<Block> {
+fn else_block(input: Span) -> IResult<Located<Block>> {
     delimited(pair(tag("else"), multispace1), block1, multispace0)(input)
 }

--- a/src/parser/node/fn_def.rs
+++ b/src/parser/node/fn_def.rs
@@ -24,7 +24,7 @@ use nom::{
 use nom_locate::position;
 
 use crate::{
-    ast::{Block, Located, Location, Name, Node, NodeKind},
+    ast::{Block, Located, Location, Name, Node},
     parser::{
         block::block0,
         helpers::{in_brackets, surrounded},
@@ -41,7 +41,7 @@ use crate::{
 /// - Spaces or line breaks after the `")"` at the end of the arguments.
 ///
 /// Other spacing details are in the docs for the other parsers of this module.
-pub fn fn_def(input: Span) -> IResult<Node> {
+pub fn fn_def(input: Span) -> IResult<Located<Node>> {
     map(
         tuple((
             fn_name,
@@ -52,8 +52,8 @@ pub fn fn_def(input: Span) -> IResult<Node> {
         |(name, args, opt_ty, body)| {
             let loc1 = name.loc;
             let loc2 = body.loc;
-            Node::new(
-                NodeKind::FnDef(name.content, args.content, body.content, opt_ty),
+            Located::new(
+                Node::FnDef(name.content, args.content, body.content, opt_ty),
                 loc1 + loc2,
             )
         },

--- a/src/parser/node/fn_def.rs
+++ b/src/parser/node/fn_def.rs
@@ -100,7 +100,7 @@ pub fn args<'a, O: std::fmt::Debug>(
 /// The body is parsed as a `Block`. This parser requires that the body is preceded by `"do"` and
 /// at least one space or line break, and followed by zero or more spaces or line breaks and an
 /// `"end"`.
-pub fn fn_body(input: Span) -> IResult<Located<Block>> {
+pub fn fn_body(input: Span) -> IResult<Located<Located<Block>>> {
     map(
         tuple((
             terminated(position, pair(tag("do"), multispace1)),

--- a/src/parser/node/fn_def.rs
+++ b/src/parser/node/fn_def.rs
@@ -24,13 +24,13 @@ use nom::{
 use nom_locate::position;
 
 use crate::{
-    ast::{Block, Located, Location, Name, Node, NodeKind, Span},
+    ast::{Block, Located, Location, Name, Node, NodeKind},
     parser::{
         block::block0,
         helpers::{in_brackets, surrounded},
         name::name,
         ty::{binding, colon_ty},
-        IResult,
+        IResult, Span,
     },
 };
 
@@ -68,7 +68,7 @@ fn fn_name(input: Span) -> IResult<Located<Option<Located<Name>>>> {
     map(
         separated_pair(position, tag("fn"), opt(preceded(space1, name))),
         |(span, opt_name)| {
-            let mut loc = span.into();
+            let mut loc = Location::from(span);
             if let Some(name) = opt_name.as_ref() {
                 loc = loc + name.loc;
             }

--- a/src/parser/node/fn_def.rs
+++ b/src/parser/node/fn_def.rs
@@ -41,6 +41,8 @@ use crate::{
 /// - Spaces or line breaks after the `")"` at the end of the arguments.
 ///
 /// Other spacing details are in the docs for the other parsers of this module.
+///
+/// The location of the returned node matches the start of the `fn` and the end of the `end`.
 pub fn fn_def(input: Span) -> IResult<Located<Node>> {
     map(
         tuple((
@@ -64,6 +66,8 @@ pub fn fn_def(input: Span) -> IResult<Located<Node>> {
 ///
 /// This parser requires that the name is preceded by `"fn"` and at least one space. If the
 /// function does not have a name, it need to parse the `"fn"` only.
+///
+/// The location of the returned node matches the start of the `fn` and the end of the name.
 fn fn_name(input: Span) -> IResult<Located<Option<Located<Name>>>> {
     map(
         separated_pair(position, tag("fn"), opt(preceded(space1, name))),
@@ -86,6 +90,8 @@ fn fn_name(input: Span) -> IResult<Located<Option<Located<Name>>>> {
 ///
 /// The arguments must be surrounded by brackets and seperated by commas. There can be spaces
 /// before the comma and spaces or line breaks after the comma.
+///
+/// The location of the returned vector starts in `(` and ends in `)`.
 pub fn args<'a, O: std::fmt::Debug>(
     content: impl Fn(Span<'a>) -> IResult<'a, O>,
 ) -> impl Fn(Span<'a>) -> IResult<'a, Located<Vec<O>>> {
@@ -100,6 +106,8 @@ pub fn args<'a, O: std::fmt::Debug>(
 /// The body is parsed as a `Block`. This parser requires that the body is preceded by `"do"` and
 /// at least one space or line break, and followed by zero or more spaces or line breaks and an
 /// `"end"`.
+///
+/// The location of the returned vector starts in `do` and ends in `end`.
 pub fn fn_body(input: Span) -> IResult<Located<Located<Block>>> {
     map(
         tuple((

--- a/src/parser/node/fn_rec_def.rs
+++ b/src/parser/node/fn_rec_def.rs
@@ -33,6 +33,8 @@ use crate::{
 /// Parses a [`Node::FnDef`].
 ///
 /// The spacing works the same as with function definitions module.
+///
+/// The location of the returned node matches the start of the `fn` and the end of the `end`.
 pub fn fn_rec_def(input: Span) -> IResult<Located<Node>> {
     map(
         tuple((
@@ -56,6 +58,8 @@ pub fn fn_rec_def(input: Span) -> IResult<Located<Node>> {
 ///
 /// This parser requires that the name is preceded by `"fn"`, at least one space, `"rec"` and at
 /// least another space.
+///
+/// The location of the returned node matches the start of the `fn` and the end of the name.
 fn fn_rec_name(input: Span) -> IResult<Located<Located<Name>>> {
     map(
         separated_pair(

--- a/src/parser/node/fn_rec_def.rs
+++ b/src/parser/node/fn_rec_def.rs
@@ -20,7 +20,7 @@ use nom::{
 use nom_locate::position;
 
 use crate::{
-    ast::{Located, Location, Name, Node, NodeKind},
+    ast::{Located, Location, Name, Node},
     parser::{
         helpers::surrounded,
         name::name,
@@ -30,10 +30,10 @@ use crate::{
     },
 };
 
-/// Parses a [`Node::FnDef`].
+/// Parses a [`FnDef`].
 ///
 /// The spacing works the same as with function definitions module.
-pub fn fn_rec_def(input: Span) -> IResult<Node> {
+pub fn fn_rec_def(input: Span) -> IResult<Located<Node>> {
     map(
         tuple((
             fn_rec_name,
@@ -44,8 +44,8 @@ pub fn fn_rec_def(input: Span) -> IResult<Node> {
         |(name, args, ty, body)| {
             let loc1 = name.loc;
             let loc2 = body.loc;
-            Node::new(
-                NodeKind::FnRecDef(name.content, args.content, body.content, ty),
+            Located::new(
+                Node::FnRecDef(name.content, args.content, body.content, ty),
                 loc1 + loc2,
             )
         },

--- a/src/parser/node/fn_rec_def.rs
+++ b/src/parser/node/fn_rec_def.rs
@@ -30,7 +30,7 @@ use crate::{
     },
 };
 
-/// Parses a [`FnDef`].
+/// Parses a [`Node::FnDef`].
 ///
 /// The spacing works the same as with function definitions module.
 pub fn fn_rec_def(input: Span) -> IResult<Located<Node>> {

--- a/src/parser/node/fn_rec_def.rs
+++ b/src/parser/node/fn_rec_def.rs
@@ -20,15 +20,13 @@ use nom::{
 use nom_locate::position;
 
 use crate::{
-    ast::{Located, Location, Name, Node, NodeKind, Span},
+    ast::{Located, Location, Name, Node, NodeKind},
     parser::{
         helpers::surrounded,
         name::name,
-        node::{
-            fn_def::{args, fn_body},
-            IResult,
-        },
+        node::fn_def::{args, fn_body},
         ty::{binding, colon_ty},
+        IResult, Span,
     },
 };
 

--- a/src/parser/node/fn_rec_def.rs
+++ b/src/parser/node/fn_rec_def.rs
@@ -15,9 +15,7 @@ use nom::{
     bytes::complete::tag,
     character::complete::{multispace0, space0, space1},
     combinator::map,
-    error::ParseError,
     sequence::{preceded, terminated, tuple},
-    IResult,
 };
 use nom_locate::position;
 
@@ -26,7 +24,10 @@ use crate::{
     parser::{
         helpers::surrounded,
         name::name,
-        node::fn_def::{args, fn_body},
+        node::{
+            fn_def::{args, fn_body},
+            IResult,
+        },
         ty::{binding, colon_ty},
     },
 };
@@ -34,7 +35,7 @@ use crate::{
 /// Parses a [`Node::FnDef`].
 ///
 /// The spacing works the same as with function definitions module.
-pub fn fn_rec_def<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Node, E> {
+pub fn fn_rec_def(input: Span) -> IResult<Node> {
     let (input, span) = position(input)?;
     map(
         tuple((
@@ -54,6 +55,6 @@ pub fn fn_rec_def<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<
 ///
 /// This parser requires that the name is preceded by `"fn"`, at least one space, `"rec"` and at
 /// least another space.
-fn fn_rec_name<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Name, E> {
+fn fn_rec_name(input: Span) -> IResult<Name> {
     preceded(tuple((tag("fn"), space1, tag("rec"), space1)), name)(input)
 }

--- a/src/parser/node/let_bind.rs
+++ b/src/parser/node/let_bind.rs
@@ -15,8 +15,8 @@ use nom::{
 };
 
 use crate::{
-    ast::{Node, NodeKind, Span},
-    parser::{helpers::surrounded, name::name, node::node, ty::colon_ty, IResult},
+    ast::{Node, NodeKind},
+    parser::{helpers::surrounded, name::name, node::node, ty::colon_ty, IResult, Span},
 };
 
 /// Parses a [`Node::LetBind`].

--- a/src/parser/node/let_bind.rs
+++ b/src/parser/node/let_bind.rs
@@ -13,7 +13,6 @@ use nom::{
     combinator::{map, opt},
     sequence::{preceded, tuple},
 };
-use nom_locate::position;
 
 use crate::{
     ast::{Node, NodeKind, Span},
@@ -24,16 +23,15 @@ use crate::{
 ///
 /// There can be any number of spaces surrounding the `=` sign.
 pub fn let_bind(input: Span) -> IResult<Node> {
-    let (input, span) = position(input)?;
     map(
         tuple((
             name,
             opt(colon_ty),
             preceded(surrounded(char('='), space0), node),
         )),
-        move |(name, opt_ty, node)| Node {
-            kind: NodeKind::LetBind(name, opt_ty, Box::new(node)),
-            span,
+        |(name, opt_ty, node)| {
+            let loc = name.loc + node.loc;
+            Node::new(NodeKind::LetBind(name, opt_ty, Box::new(node)), loc)
         },
     )(input)
 }

--- a/src/parser/node/let_bind.rs
+++ b/src/parser/node/let_bind.rs
@@ -8,26 +8,22 @@
 //! ```
 //!
 //! Meaning that type bindings are optional.
-
 use nom::{
     character::complete::{char, space0},
     combinator::{map, opt},
-    error::ParseError,
     sequence::{preceded, tuple},
-    IResult,
 };
 use nom_locate::position;
 
 use crate::{
     ast::{Node, NodeKind, Span},
-    parser::{helpers::surrounded, name::name, node::node, ty::colon_ty},
+    parser::{helpers::surrounded, name::name, node::node, ty::colon_ty, IResult},
 };
 
 /// Parses a [`Node::LetBind`].
 ///
 /// There can be any number of spaces surrounding the `=` sign.
-
-pub fn let_bind<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Node, E> {
+pub fn let_bind(input: Span) -> IResult<Node> {
     let (input, span) = position(input)?;
     map(
         tuple((

--- a/src/parser/node/let_bind.rs
+++ b/src/parser/node/let_bind.rs
@@ -4,7 +4,7 @@
 //! the rule
 //!
 //! ```abnf
-//! let_bind = name (":" ty)? "=" expr
+//! let_bind = name (":" ty)? "=" node
 //! ```
 //!
 //! Meaning that type bindings are optional.
@@ -22,6 +22,9 @@ use crate::{
 /// Parses a [`Node::LetBind`].
 ///
 /// There can be any number of spaces surrounding the `=` sign.
+///
+/// The location of the returned node matches the start of the name and the end of the node after
+/// the `=`.
 pub fn let_bind(input: Span) -> IResult<Located<Node>> {
     map(
         tuple((

--- a/src/parser/node/let_bind.rs
+++ b/src/parser/node/let_bind.rs
@@ -16,9 +16,10 @@ use nom::{
     sequence::{preceded, tuple},
     IResult,
 };
+use nom_locate::position;
 
 use crate::{
-    ast::Node,
+    ast::{Node, NodeKind, Span},
     parser::{helpers::surrounded, name::name, node::node, ty::colon_ty},
 };
 
@@ -26,13 +27,17 @@ use crate::{
 ///
 /// There can be any number of spaces surrounding the `=` sign.
 
-pub fn let_bind<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Node, E> {
+pub fn let_bind<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Node, E> {
+    let (input, span) = position(input)?;
     map(
         tuple((
             name,
             opt(colon_ty),
             preceded(surrounded(char('='), space0), node),
         )),
-        |(name, opt_ty, node)| Node::LetBind(name, opt_ty, Box::new(node)),
+        move |(name, opt_ty, node)| Node {
+            kind: NodeKind::LetBind(name, opt_ty, Box::new(node)),
+            span,
+        },
     )(input)
 }

--- a/src/parser/node/let_bind.rs
+++ b/src/parser/node/let_bind.rs
@@ -15,14 +15,14 @@ use nom::{
 };
 
 use crate::{
-    ast::{Node, NodeKind},
+    ast::{Located, Node},
     parser::{helpers::surrounded, name::name, node::node, ty::colon_ty, IResult, Span},
 };
 
 /// Parses a [`Node::LetBind`].
 ///
 /// There can be any number of spaces surrounding the `=` sign.
-pub fn let_bind(input: Span) -> IResult<Node> {
+pub fn let_bind(input: Span) -> IResult<Located<Node>> {
     map(
         tuple((
             name,
@@ -31,7 +31,7 @@ pub fn let_bind(input: Span) -> IResult<Node> {
         )),
         |(name, opt_ty, node)| {
             let loc = name.loc + node.loc;
-            Node::new(NodeKind::LetBind(name, opt_ty, Box::new(node)), loc)
+            Located::new(Node::LetBind(name, opt_ty, Box::new(node)), loc)
         },
     )(input)
 }

--- a/src/parser/node/mod.rs
+++ b/src/parser/node/mod.rs
@@ -6,7 +6,6 @@
 //!
 //! The [`binary_op`] module is particularly important here so it is a good idea to check those
 //! module docs too.
-
 mod binary_op;
 mod call;
 mod cond;
@@ -20,25 +19,25 @@ use nom::{
     bytes::complete::tag,
     character::complete::{multispace1, space1},
     combinator::map,
-    error::ParseError,
     sequence::{pair, tuple},
-    IResult,
 };
 use nom_locate::position;
 
-use crate::ast::{Node, NodeKind, Span};
-
-use crate::parser::{
-    helpers::{in_brackets, lookahead},
-    literal::literal,
-    name::name,
-    un_op::un_op,
+use crate::{
+    ast::{Node, NodeKind, Span},
+    parser::{
+        helpers::{in_brackets, lookahead},
+        literal::literal,
+        name::name,
+        un_op::un_op,
+        IResult,
+    },
 };
 
 /// Parser for [`Node`]s.
 ///
 /// To understand its behaviour please refer to the [`binary_op`] docs.
-pub fn node<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Node<'a>, E> {
+pub fn node(input: Span) -> IResult<Node> {
     binary_op::binary_op(input)
 }
 
@@ -59,7 +58,7 @@ pub fn node<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, N
 /// - If the input starts with a unary operator, the [`un_op`] parser is applied.
 ///
 /// This function is very order sensitive. Be careful if you swap the parsers order.
-fn base_node<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Node, E> {
+fn base_node(input: Span) -> IResult<Node> {
     alt((
         in_brackets(node),
         map(pair(position, literal), |(span, lit)| Node {

--- a/src/parser/node/mod.rs
+++ b/src/parser/node/mod.rs
@@ -23,13 +23,13 @@ use nom::{
 };
 
 use crate::{
-    ast::{Located, Node, NodeKind, Span},
+    ast::{Located, Node, NodeKind},
     parser::{
         helpers::{in_brackets, lookahead},
         literal::literal,
         name::name,
         un_op::un_op,
-        IResult,
+        IResult, Span,
     },
 };
 

--- a/src/parser/node/mod.rs
+++ b/src/parser/node/mod.rs
@@ -23,7 +23,7 @@ use nom::{
 };
 
 use crate::{
-    ast::{Located, Node, NodeKind},
+    ast::{Located, Node},
     parser::{
         helpers::{in_brackets, lookahead},
         literal::literal,
@@ -36,7 +36,7 @@ use crate::{
 /// Parser for [`Node`]s.
 ///
 /// To understand its behaviour please refer to the [`binary_op`] docs.
-pub fn node(input: Span) -> IResult<Node> {
+pub fn node(input: Span) -> IResult<Located<Node>> {
     binary_op::binary_op(input)
 }
 
@@ -57,14 +57,14 @@ pub fn node(input: Span) -> IResult<Node> {
 /// - If the input starts with a unary operator, the [`un_op`] parser is applied.
 ///
 /// This function is very order sensitive. Be careful if you swap the parsers order.
-fn base_node(input: Span) -> IResult<Node> {
+fn base_node(input: Span) -> IResult<Located<Node>> {
     alt((
         map(in_brackets(node), |Located { mut content, loc }| {
             content.loc = loc;
             content
         }),
         map(literal, |Located { content, loc }| {
-            Node::new(NodeKind::Literal(content), loc)
+            Located::new(Node::Literal(content), loc)
         }),
         lookahead(pair(tag("if"), multispace1), cond::cond),
         lookahead(
@@ -78,7 +78,7 @@ fn base_node(input: Span) -> IResult<Node> {
                 let_bind::let_bind,
                 call::call,
                 map(name, |Located { content, loc }| {
-                    Node::new(NodeKind::Name(content), loc)
+                    Located::new(Node::Name(content), loc)
                 }),
             )),
         ),

--- a/src/parser/node/unary_op.rs
+++ b/src/parser/node/unary_op.rs
@@ -4,17 +4,19 @@
 //! levels for these operations. It uses the [`un_op`] parser.
 //!
 //! [`un_op`]: crate::parser::un_op
-
 use nom::{combinator::map, error::ParseError, sequence::pair, IResult};
+use nom_locate::position;
 
 use crate::{
-    ast::Node,
+    ast::{Node, NodeKind, Span},
     parser::{node::node, un_op::*},
 };
 
 /// Parses a [`Node::UnaryOp`].
-pub fn unary_op<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Node, E> {
-    map(pair(un_op, node), |(un_op, node)| {
-        Node::UnaryOp(un_op, Box::new(node))
+pub fn unary_op<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Node, E> {
+    let (input, span) = position(input)?;
+    map(pair(un_op, node), move |(un_op, node)| Node {
+        kind: NodeKind::UnaryOp(un_op, Box::new(node)),
+        span,
     })(input)
 }

--- a/src/parser/node/unary_op.rs
+++ b/src/parser/node/unary_op.rs
@@ -8,8 +8,8 @@ use nom::{combinator::map, sequence::pair};
 use nom_locate::position;
 
 use crate::{
-    ast::{Location, Node, NodeKind, Span},
-    parser::{node::node, un_op::*, IResult},
+    ast::{Location, Node, NodeKind},
+    parser::{node::node, un_op::un_op, IResult, Span},
 };
 
 /// Parses a [`Node::UnaryOp`].

--- a/src/parser/node/unary_op.rs
+++ b/src/parser/node/unary_op.rs
@@ -8,15 +8,20 @@ use nom::{combinator::map, sequence::pair};
 use nom_locate::position;
 
 use crate::{
-    ast::{Node, NodeKind, Span},
+    ast::{Location, Node, NodeKind, Span},
     parser::{node::node, un_op::*, IResult},
 };
 
 /// Parses a [`Node::UnaryOp`].
 pub fn unary_op(input: Span) -> IResult<Node> {
-    let (input, span) = position(input)?;
-    map(pair(un_op, node), move |(un_op, node)| Node {
-        kind: NodeKind::UnaryOp(un_op, Box::new(node)),
-        span,
+    let (_, span) = position(input)?;
+    let start = span.location_offset();
+
+    map(pair(un_op, node), move |(un_op, node)| {
+        let end = node.loc.end;
+        Node::new(
+            NodeKind::UnaryOp(un_op, Box::new(node)),
+            Location::new(start, end),
+        )
     })(input)
 }

--- a/src/parser/node/unary_op.rs
+++ b/src/parser/node/unary_op.rs
@@ -13,6 +13,8 @@ use crate::{
 };
 
 /// Parses a [`Node::UnaryOp`].
+///
+/// The location of the returned node matches the start of the unary operation and the end of the inner node.
 pub fn unary_op(input: Span) -> IResult<Located<Node>> {
     map(tuple((position, un_op, node)), move |(sp, un_op, node)| {
         let loc = Location::from(sp) + node.loc;

--- a/src/parser/node/unary_op.rs
+++ b/src/parser/node/unary_op.rs
@@ -4,16 +4,16 @@
 //! levels for these operations. It uses the [`un_op`] parser.
 //!
 //! [`un_op`]: crate::parser::un_op
-use nom::{combinator::map, error::ParseError, sequence::pair, IResult};
+use nom::{combinator::map, sequence::pair};
 use nom_locate::position;
 
 use crate::{
     ast::{Node, NodeKind, Span},
-    parser::{node::node, un_op::*},
+    parser::{node::node, un_op::*, IResult},
 };
 
 /// Parses a [`Node::UnaryOp`].
-pub fn unary_op<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Node, E> {
+pub fn unary_op(input: Span) -> IResult<Node> {
     let (input, span) = position(input)?;
     map(pair(un_op, node), move |(un_op, node)| Node {
         kind: NodeKind::UnaryOp(un_op, Box::new(node)),

--- a/src/parser/node/unary_op.rs
+++ b/src/parser/node/unary_op.rs
@@ -4,24 +4,18 @@
 //! levels for these operations. It uses the [`un_op`] parser.
 //!
 //! [`un_op`]: crate::parser::un_op
-use nom::{combinator::map, sequence::pair};
+use nom::{combinator::map, sequence::tuple};
 use nom_locate::position;
 
 use crate::{
-    ast::{Location, Node, NodeKind},
+    ast::{Located, Location, Node},
     parser::{node::node, un_op::un_op, IResult, Span},
 };
 
 /// Parses a [`Node::UnaryOp`].
-pub fn unary_op(input: Span) -> IResult<Node> {
-    let (_, span) = position(input)?;
-    let start = span.location_offset();
-
-    map(pair(un_op, node), move |(un_op, node)| {
-        let end = node.loc.end;
-        Node::new(
-            NodeKind::UnaryOp(un_op, Box::new(node)),
-            Location::new(start, end),
-        )
+pub fn unary_op(input: Span) -> IResult<Located<Node>> {
+    map(tuple((position, un_op, node)), move |(sp, un_op, node)| {
+        let loc = Location::from(sp) + node.loc;
+        Located::new(Node::UnaryOp(un_op, Box::new(node)), loc)
     })(input)
 }

--- a/src/parser/ty.rs
+++ b/src/parser/ty.rs
@@ -43,11 +43,11 @@ use nom::{
 };
 
 use crate::{
-    ast::{Located, Location, Span},
+    ast::{Located, Location},
     parser::{
         helpers::{in_brackets, surrounded},
         name::name,
-        IResult,
+        IResult, Span,
     },
     ty::{Binding, Ty},
 };
@@ -114,13 +114,9 @@ pub fn colon_ty(input: Span) -> IResult<Located<Ty>> {
 /// There can be any number of spaces between the brackets and its contents.
 fn base_ty(input: Span) -> IResult<Located<Ty>> {
     alt((
-        map(tag("Bool"), |span: Span| {
-            Located::new(Ty::Bool, span.into())
-        }),
-        map(tag("Int"), |span: Span| Located::new(Ty::Int, span.into())),
-        map(tag("Unit"), |span: Span| {
-            Located::new(Ty::Unit, span.into())
-        }),
+        map(tag("Bool"), |span: Span| Located::new(Ty::Bool, span)),
+        map(tag("Int"), |span: Span| Located::new(Ty::Int, span)),
+        map(tag("Unit"), |span: Span| Located::new(Ty::Unit, span)),
         map(in_brackets(ty), |Located { mut content, loc }| {
             content.loc = loc;
             content

--- a/src/parser/ty.rs
+++ b/src/parser/ty.rs
@@ -60,6 +60,9 @@ use crate::{
 /// `Bool -> (Int -> Unit)`.
 ///
 /// There can be any number of spaces surrounding the `->`, including no spaces at all.
+///
+/// If the returned type is an `Arrow`, the location matches the start of the first type
+/// and the end of the second. For any other case refer to the [`base_ty`] docs.
 pub fn ty(input: Span) -> IResult<Located<Ty>> {
     let (rem, t1) = base_ty(input)?;
     if let (rem, Some(t2)) = opt(preceded(surrounded(tag("->"), space0), ty))(rem)? {
@@ -112,6 +115,10 @@ pub fn colon_ty(input: Span) -> IResult<Located<Ty>> {
 /// round brackets. It returns a [`Ty`].
 ///
 /// There can be any number of spaces between the brackets and its contents.
+///
+/// If the returned type is one of the string slices mentioned above, the location matches the one
+/// of the slice. If the returned type is surrounded by brackets, the location matches the span of
+/// the brackets.
 fn base_ty(input: Span) -> IResult<Located<Ty>> {
     alt((
         map(tag("Bool"), |span: Span| Located::new(Ty::Bool, span)),

--- a/src/parser/ty.rs
+++ b/src/parser/ty.rs
@@ -39,9 +39,7 @@ use nom::{
     bytes::complete::tag,
     character::complete::{char, space0},
     combinator::{map, opt},
-    error::ParseError,
     sequence::{pair, preceded},
-    IResult,
 };
 
 use crate::{
@@ -49,6 +47,7 @@ use crate::{
     parser::{
         helpers::{in_brackets, surrounded},
         name::name,
+        IResult,
     },
     ty::{Binding, Ty},
 };
@@ -61,7 +60,7 @@ use crate::{
 /// `Bool -> (Int -> Unit)`.
 ///
 /// There can be any number of spaces surrounding the `->`, including no spaces at all.
-pub fn ty<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Ty, E> {
+pub fn ty(input: Span) -> IResult<Ty> {
     let (rem, t1) = base_ty(input)?;
     if let (rem, Some(t2)) = opt(preceded(surrounded(tag("->"), space0), ty))(rem)? {
         Ok((rem, Ty::Arrow(Box::new(t1), Box::new(t2))))
@@ -74,7 +73,7 @@ pub fn ty<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Ty,
 ///
 /// This parser returns a [`Binding`], there can be any number of spaces surrounding the `:`,
 /// including no spaces at all.
-pub fn binding<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Binding, E> {
+pub fn binding(input: Span) -> IResult<Binding> {
     map(pair(name, colon_ty), |(name, ty)| Binding { name, ty })(input)
 }
 
@@ -85,7 +84,7 @@ pub fn binding<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>
 /// This parser exists with the sole purpose of being reutilized for type bindings that are not
 /// stored in [`Binding`]s such as the return type of functions or the optional type binding for
 /// let bindings.
-pub fn colon_ty<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Ty, E> {
+pub fn colon_ty(input: Span) -> IResult<Ty> {
     preceded(surrounded(char(':'), space0), ty)(input)
 }
 
@@ -95,7 +94,7 @@ pub fn colon_ty<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a
 /// round brackets. It returns a [`Ty`].
 ///
 /// There can be any number of spaces between the brackets and its contents.
-fn base_ty<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, Ty, E> {
+fn base_ty(input: Span) -> IResult<Ty> {
     alt((
         map(tag("Bool"), |_| Ty::Bool),
         map(tag("Int"), |_| Ty::Int),

--- a/src/parser/un_op.rs
+++ b/src/parser/un_op.rs
@@ -13,12 +13,15 @@ use nom::{
     IResult,
 };
 
-use crate::ast::UnOp::{self, *};
+use crate::ast::{
+    Span,
+    UnOp::{self, *},
+};
 
 /// Parser for the unary operators `!` and `-`.
 ///
 /// All the unary operators might be followed by zero or more spaces.
-pub fn un_op<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, UnOp, E> {
+pub fn un_op<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, UnOp, E> {
     terminated(
         alt((map(char('!'), |_| Not), map(char('-'), |_| Neg))),
         space0,

--- a/src/parser/un_op.rs
+++ b/src/parser/un_op.rs
@@ -12,11 +12,8 @@ use nom::{
 };
 
 use crate::{
-    ast::{
-        Span,
-        UnOp::{self, *},
-    },
-    parser::IResult,
+    ast::{UnOp, UnOp::*},
+    parser::{IResult, Span},
 };
 
 /// Parser for the unary operators `!` and `-`.

--- a/src/parser/un_op.rs
+++ b/src/parser/un_op.rs
@@ -8,20 +8,21 @@ use nom::{
     branch::alt,
     character::complete::{char, space0},
     combinator::map,
-    error::ParseError,
     sequence::terminated,
-    IResult,
 };
 
-use crate::ast::{
-    Span,
-    UnOp::{self, *},
+use crate::{
+    ast::{
+        Span,
+        UnOp::{self, *},
+    },
+    parser::IResult,
 };
 
 /// Parser for the unary operators `!` and `-`.
 ///
 /// All the unary operators might be followed by zero or more spaces.
-pub fn un_op<'a, E: ParseError<Span<'a>>>(input: Span<'a>) -> IResult<Span<'a>, UnOp, E> {
+pub fn un_op(input: Span) -> IResult<UnOp> {
     terminated(
         alt((map(char('!'), |_| Not), map(char('-'), |_| Neg))),
         space0,

--- a/src/ty/ty_check.rs
+++ b/src/ty/ty_check.rs
@@ -1,7 +1,7 @@
 use thiserror::Error;
 
 use crate::{
-    ast::{BinOp, Literal, Located, UnOp, Location},
+    ast::{BinOp, Literal, Located, Location, UnOp},
     mir::Term,
     ty::{Binding, Ty},
 };

--- a/src/ty/ty_check.rs
+++ b/src/ty/ty_check.rs
@@ -19,7 +19,6 @@ pub fn expect_ty(expected: Ty, found: Located<Ty>) -> TyResult {
 }
 
 /// Macro version of `expect_ty` that accepts a comma separated list of types to check.
-#[macro_export]
 macro_rules! ensure_ty {
     ($expected:expr, $found:expr) => {
         crate::ty::expect_ty($expected, $found)

--- a/src/ty/ty_check.rs
+++ b/src/ty/ty_check.rs
@@ -1,20 +1,26 @@
 use thiserror::Error;
 
 use crate::{
-    ast::{BinOp, Literal, Located, UnOp},
+    ast::{BinOp, Literal, Located, UnOp, Location},
     mir::Term,
     ty::{Binding, Ty},
 };
 
-pub fn ty_check(term: &Located<Term<'_>>) -> TyResult {
-    Context::default().type_of(&term.content)
+pub fn ty_check(term: &Located<Term<'_>>) -> TyResult<Located<Ty>> {
+    Context::default().type_of(&term)
 }
 
-pub fn expect_ty(expected: Ty, found: Ty) -> TyResult {
-    if expected == found {
-        Ok(expected)
+pub fn expect_ty(expected: Ty, found: Located<Ty>) -> TyResult<Located<Ty>> {
+    if expected == found.content {
+        Ok(found)
     } else {
-        Err(TyError::Mismatch { expected, found })
+        Err(TyError {
+            loc: found.loc,
+            kind: TyErrorKind::Mismatch {
+                expected,
+                found: found.content,
+            },
+        })
     }
 }
 
@@ -22,10 +28,10 @@ pub fn expect_ty(expected: Ty, found: Ty) -> TyResult {
 macro_rules! ensure_ty {
     ($expected:path, $found:ident, $( $other:ident ),*) => {
         // Using a closure to benefit from early exit via ? without interfering with the caller
-        move || -> TyResult<Ty> {
+        move || -> TyResult<Located<Ty>> {
             let ty = expect_ty($expected, $found)?;
             $(
-                let ty = expect_ty(ty, $other)?;
+                let ty = expect_ty($expected, $other)?;
             )*
             Ok(ty)
         }()
@@ -33,7 +39,14 @@ macro_rules! ensure_ty {
 }
 
 #[derive(Error, Debug)]
-pub enum TyError {
+#[error("{kind}")]
+pub struct TyError {
+    pub loc: Location,
+    pub kind: TyErrorKind,
+}
+
+#[derive(Error, Debug)]
+pub enum TyErrorKind {
     #[error("Type mismatch: expected {expected}, found {found}")]
     Mismatch { expected: Ty, found: Ty },
     #[error("Name {0} is unbounded")]
@@ -52,36 +65,46 @@ struct Context<'a> {
 }
 
 impl<'a> Context<'a> {
-    fn type_of(&mut self, term: &Term<'a>) -> TyResult {
-        let ty = match term {
-            Term::Lit(lit) => match lit {
-                Literal::Unit => Ty::Unit,
-                Literal::Bool(_) => Ty::Bool,
-                Literal::Number(_) => Ty::Int,
-            },
-            Term::Var(name) => self
-                .inner
-                .iter()
-                .find(|bind| bind.name == *name)
-                .ok_or_else(|| TyError::Unbound(name.0.to_string()))?
-                .ty
-                .clone(),
+    fn type_of(&mut self, term: &Located<Term<'a>>) -> TyResult<Located<Ty>> {
+        let loc = term.loc;
+        let ty = match &term.content {
+            Term::Lit(lit) => {
+                let ty = match lit {
+                    Literal::Unit => Ty::Unit,
+                    Literal::Bool(_) => Ty::Bool,
+                    Literal::Number(_) => Ty::Int,
+                };
+                Located::new(ty, loc)
+            }
+            Term::Var(name) => {
+                let ty = self
+                    .inner
+                    .iter()
+                    .find(|bind| bind.name == *name)
+                    .ok_or_else(|| TyError {
+                        loc,
+                        kind: TyErrorKind::Unbound(name.0.to_string()),
+                    })?
+                    .ty
+                    .clone();
+                Located::new(ty, loc)
+            }
             Term::Abs(bind, body) => {
                 self.inner.push(bind.clone());
-                let ty = self.type_of(&body.content)?;
+                let ty = self.type_of(body.as_ref())?.content;
                 self.inner.pop().unwrap();
-                Ty::Arrow(Box::new(bind.ty.clone()), Box::new(ty))
+                Located::new(Ty::Arrow(Box::new(bind.ty.clone()), Box::new(ty)), loc)
             }
             Term::UnaryOp(op, term) => {
-                let ty = self.type_of(&term.content)?;
+                let ty = self.type_of(term.as_ref())?;
                 match op {
                     UnOp::Neg => expect_ty(Ty::Int, ty)?,
                     UnOp::Not => expect_ty(Ty::Bool, ty)?,
                 }
             }
             Term::BinaryOp(op, t1, t2) => {
-                let ty1 = self.type_of(&t1.content)?;
-                let ty2 = self.type_of(&t2.content)?;
+                let ty1 = self.type_of(t1.as_ref())?;
+                let ty2 = self.type_of(t2.as_ref())?;
                 match op {
                     BinOp::Add
                     | BinOp::Sub
@@ -96,53 +119,64 @@ impl<'a> Context<'a> {
                     BinOp::Or | BinOp::And => ensure_ty!(Ty::Bool, ty1, ty2)?,
                     BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte => {
                         ensure_ty!(Ty::Int, ty1, ty2)?;
-                        Ty::Bool
+                        Located::new(Ty::Bool, loc)
                     }
                     BinOp::Eq | BinOp::Neq => {
-                        expect_ty(ty1, ty2)?;
-                        Ty::Bool
+                        expect_ty(ty1.content, ty2)?;
+                        Located::new(Ty::Bool, loc)
                     }
                 }
             }
             Term::App(t1, t2) => {
-                let ty1 = self.type_of(&t1.content)?;
-                let ty2 = self.type_of(&t2.content)?;
-                match ty1 {
+                let ty1 = self.type_of(t1.as_ref())?;
+                let ty2 = self.type_of(t2.as_ref())?;
+                match ty1.content {
                     Ty::Arrow(ty11, ty) => {
                         expect_ty(*ty11, ty2)?;
-                        *ty
+                        Located::new(*ty, loc)
                     }
-                    _ => return Err(TyError::NotFn(ty1)),
+                    _ => {
+                        return Err(TyError {
+                            kind: TyErrorKind::NotFn(ty1.content),
+                            loc: ty1.loc,
+                        })
+                    }
                 }
             }
             Term::Let(name, t1, t2) => {
-                let bind = self.type_of(&t1.content).map(|ty| Binding {
+                let bind = self.type_of(t1.as_ref()).map(|ty| Binding {
                     name: name.content,
-                    ty,
+                    ty: ty.content,
                 })?;
                 self.inner.push(bind);
-                let ty2 = self.type_of(&t2.content)?;
+                let ty2 = self.type_of(t2.as_ref())?;
                 self.inner.pop().unwrap();
                 ty2
             }
             Term::Cond(t1, t2, t3) => {
-                let ty1 = self.type_of(&t1.content)?;
-                let ty2 = self.type_of(&t2.content)?;
-                let ty3 = self.type_of(&t3.content)?;
+                let ty1 = self.type_of(t1.as_ref())?;
+                let ty2 = self.type_of(t2.as_ref())?;
+                let ty3 = self.type_of(t3.as_ref())?;
                 expect_ty(Ty::Bool, ty1)?;
-                expect_ty(ty2, ty3)?
+                expect_ty(ty2.content, ty3)?
             }
             Term::Seq(t1, t2) => {
-                let ty1 = self.type_of(&t1.content)?;
+                let ty1 = self.type_of(t1.as_ref())?;
                 expect_ty(Ty::Unit, ty1)?;
-                self.type_of(&t2.content)?
+                self.type_of(t2.as_ref())?
             }
-            Term::Fix(t1) => match self.type_of(&t1.content)? {
-                Ty::Arrow(box ty1, box ty2) => expect_ty(ty1, ty2)?,
-                ty => {
-                    return Err(TyError::NotFn(ty));
+            Term::Fix(t1) => {
+                let ty = self.type_of(t1.as_ref())?;
+                match ty.content {
+                    Ty::Arrow(box ty1, box ty2) => expect_ty(ty1, Located::new(ty2, ty.loc))?,
+                    _ => {
+                        return Err(TyError {
+                            kind: TyErrorKind::NotFn(ty.content),
+                            loc: ty.loc,
+                        });
+                    }
                 }
-            },
+            }
         };
         Ok(ty)
     }

--- a/src/ty/ty_check.rs
+++ b/src/ty/ty_check.rs
@@ -63,7 +63,7 @@ impl<'a> Context<'a> {
                 .inner
                 .iter()
                 .find(|bind| bind.name == *name)
-                .ok_or_else(|| TyError::Unbound(name.0.to_owned()))?
+                .ok_or_else(|| TyError::Unbound(name.0.to_string()))?
                 .ty
                 .clone(),
             Term::Abs(bind, body) => {

--- a/tests/eval/mod.rs
+++ b/tests/eval/mod.rs
@@ -5,7 +5,7 @@ use pijama::{ast::Literal, lir::Term, run, LangResult};
 use crate::panic_after;
 
 #[test]
-fn arithmetic() -> LangResult<()> {
+fn arithmetic() -> LangResult<'static, ()> {
     let input = include_str!("arithmetic.pj");
     let term = run(input)?;
     assert_eq!(Term::Lit(Literal::Number(121)), term);
@@ -13,7 +13,7 @@ fn arithmetic() -> LangResult<()> {
 }
 
 #[test]
-fn logic() -> LangResult<()> {
+fn logic() -> LangResult<'static, ()> {
     let input = include_str!("logic.pj");
     let term = run(input)?;
     assert_eq!(Term::Lit(Literal::Bool(false)), term);
@@ -21,7 +21,7 @@ fn logic() -> LangResult<()> {
 }
 
 #[test]
-fn factorial() -> LangResult<()> {
+fn factorial() -> LangResult<'static, ()> {
     let input = include_str!("factorial.pj");
     let term = run(input)?;
     assert_eq!(Term::Lit(Literal::Number(3628800)), term);
@@ -29,7 +29,7 @@ fn factorial() -> LangResult<()> {
 }
 
 #[test]
-fn factorial_tail() -> LangResult<()> {
+fn factorial_tail() -> LangResult<'static, ()> {
     let input = include_str!("factorial_tail.pj");
     let term = run(input)?;
     assert_eq!(Term::Lit(Literal::Number(3628800)), term);
@@ -37,7 +37,7 @@ fn factorial_tail() -> LangResult<()> {
 }
 
 #[test]
-fn fancy_max() -> LangResult<()> {
+fn fancy_max() -> LangResult<'static, ()> {
     let input = include_str!("fancy_max.pj");
     let term = run(input)?;
     assert_eq!(Term::Lit(Literal::Number(10)), term);
@@ -45,7 +45,7 @@ fn fancy_max() -> LangResult<()> {
 }
 
 #[test]
-fn fibonacci() -> LangResult<()> {
+fn fibonacci() -> LangResult<'static, ()> {
     let input = include_str!("fibonacci.pj");
     let term = run(input)?;
     assert_eq!(Term::Lit(Literal::Number(21)), term);
@@ -53,7 +53,7 @@ fn fibonacci() -> LangResult<()> {
 }
 
 #[test]
-fn fibonacci_tail() -> LangResult<()> {
+fn fibonacci_tail() -> LangResult<'static, ()> {
     let input = include_str!("fibonacci_tail.pj");
     let term = run(input)?;
     assert_eq!(Term::Lit(Literal::Number(21)), term);
@@ -61,7 +61,7 @@ fn fibonacci_tail() -> LangResult<()> {
 }
 
 #[test]
-fn gcd() -> LangResult<()> {
+fn gcd() -> LangResult<'static, ()> {
     let input = include_str!("gcd.pj");
     let term = run(input)?;
     assert_eq!(Term::Lit(Literal::Number(1)), term);
@@ -69,7 +69,7 @@ fn gcd() -> LangResult<()> {
 }
 
 #[test]
-fn ackermann() -> LangResult<()> {
+fn ackermann() -> LangResult<'static, ()> {
     let input = include_str!("ackermann.pj");
     let term = run(input)?;
     assert_eq!(Term::Lit(Literal::Number(5)), term);
@@ -77,7 +77,7 @@ fn ackermann() -> LangResult<()> {
 }
 
 #[test]
-fn calling() -> LangResult<()> {
+fn calling() -> LangResult<'static, ()> {
     let input = include_str!("calling.pj");
     let term = run(input)?;
     assert_eq!(Term::Lit(Literal::Number(1)), term);
@@ -85,7 +85,7 @@ fn calling() -> LangResult<()> {
 }
 
 #[test]
-fn complex_calling() -> LangResult<()> {
+fn complex_calling() -> LangResult<'static, ()> {
     let input = include_str!("complex_calling.pj");
     let term = run(input)?;
     assert_eq!(Term::Lit(Literal::Number(1)), term);
@@ -93,7 +93,7 @@ fn complex_calling() -> LangResult<()> {
 }
 
 #[test]
-fn step() -> LangResult<()> {
+fn step() -> LangResult<'static, ()> {
     let input = include_str!("step.pj");
     let term = run(input)?;
     assert_eq!(Term::Lit(Literal::Number(1)), term);
@@ -101,7 +101,7 @@ fn step() -> LangResult<()> {
 }
 
 #[test]
-fn bit_and() -> LangResult<()> {
+fn bit_and() -> LangResult<'static, ()> {
     let input = include_str!("bit_and.pj");
     let term = run(input)?;
     assert_eq!(Term::Lit(Literal::Number(64)), term);
@@ -109,7 +109,7 @@ fn bit_and() -> LangResult<()> {
 }
 
 #[test]
-fn bit_or() -> LangResult<()> {
+fn bit_or() -> LangResult<'static, ()> {
     let input = include_str!("bit_or.pj");
     let term = run(input)?;
     assert_eq!(Term::Lit(Literal::Number(192)), term);
@@ -117,7 +117,7 @@ fn bit_or() -> LangResult<()> {
 }
 
 #[test]
-fn bit_xor() -> LangResult<()> {
+fn bit_xor() -> LangResult<'static, ()> {
     let input = include_str!("bit_xor.pj");
     let term = run(input)?;
     assert_eq!(Term::Lit(Literal::Number(128)), term);
@@ -125,7 +125,7 @@ fn bit_xor() -> LangResult<()> {
 }
 
 #[test]
-fn bit_shift_l() -> LangResult<()> {
+fn bit_shift_l() -> LangResult<'static, ()> {
     let input = include_str!("bit_shift_l.pj");
     let term = run(input)?;
     assert_eq!(Term::Lit(Literal::Number(128)), term);
@@ -133,7 +133,7 @@ fn bit_shift_l() -> LangResult<()> {
 }
 
 #[test]
-fn bit_shift_r() -> LangResult<()> {
+fn bit_shift_r() -> LangResult<'static, ()> {
     let input = include_str!("bit_shift_r.pj");
     let term = run(input)?;
     assert_eq!(Term::Lit(Literal::Number(32)), term);
@@ -141,7 +141,7 @@ fn bit_shift_r() -> LangResult<()> {
 }
 
 #[test]
-fn or_short_circuit() -> LangResult<()> {
+fn or_short_circuit() -> LangResult<'static, ()> {
     panic_after(Duration::from_secs(1), || {
         let input = include_str!("or_short_circuit.pj");
         let term = run(input)?;
@@ -151,7 +151,7 @@ fn or_short_circuit() -> LangResult<()> {
 }
 
 #[test]
-fn and_short_circuit() -> LangResult<()> {
+fn and_short_circuit() -> LangResult<'static, ()> {
     panic_after(Duration::from_secs(1), || {
         let input = include_str!("and_short_circuit.pj");
         let term = run(input)?;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -8,6 +8,7 @@ use std::{panic, sync::mpsc, thread, time::Duration};
 mod eval;
 mod parse;
 mod type_check;
+mod util;
 
 fn panic_after<T, F>(d: Duration, f: F) -> T
 where

--- a/tests/parse/mod.rs
+++ b/tests/parse/mod.rs
@@ -7,14 +7,16 @@ use pijama::{
     LangResult,
 };
 
+use crate::util::DummyLoc;
+
 #[test]
-fn name() -> LangResult<()> {
+fn name() -> LangResult<'static, ()> {
     let input = include_str!("name.pj");
-    let result = parse(input)?;
+    let result = parse(input)?.content;
     let expected = vec![
-        Name(ast::Name("x")),
-        Name(ast::Name("foo")),
-        Name(ast::Name("foo_bar")),
+        Name(ast::Name("x")).loc(),
+        Name(ast::Name("foo")).loc(),
+        Name(ast::Name("foo_bar")).loc(),
     ];
 
     assert_eq!(expected[0], result[0], "single letter");
@@ -24,16 +26,16 @@ fn name() -> LangResult<()> {
 }
 
 #[test]
-fn literal() -> LangResult<()> {
+fn literal() -> LangResult<'static, ()> {
     let input = include_str!("literal.pj");
-    let result = parse(input)?;
+    let result = parse(input)?.content;
     let expected = vec![
-        Literal(ast::Literal::Number(0)),
-        Literal(ast::Literal::Number(-1)),
-        Literal(ast::Literal::Number(14142)),
-        Literal(ast::Literal::Bool(true)),
-        Literal(ast::Literal::Bool(false)),
-        Literal(ast::Literal::Unit),
+        Literal(ast::Literal::Number(0)).loc(),
+        Literal(ast::Literal::Number(-1)).loc(),
+        Literal(ast::Literal::Number(14142)).loc(),
+        Literal(ast::Literal::Bool(true)).loc(),
+        Literal(ast::Literal::Bool(false)).loc(),
+        Literal(ast::Literal::Unit).loc(),
     ];
 
     assert_eq!(expected[0], result[0], "integer");
@@ -46,21 +48,38 @@ fn literal() -> LangResult<()> {
 }
 
 #[test]
-fn binary_op() -> LangResult<()> {
+fn binary_op() -> LangResult<'static, ()> {
     let input = include_str!("bin_op.pj");
-    let result = parse(input)?;
+    let result = parse(input)?.content;
     let expected = vec![
-        BinaryOp(Add, box Name(ast::Name("a")), box Name(ast::Name("b"))),
         BinaryOp(
             Add,
-            box BinaryOp(Add, box Name(ast::Name("a")), box Name(ast::Name("b"))),
-            box Name(ast::Name("c")),
-        ),
+            box Name(ast::Name("a")).loc(),
+            box Name(ast::Name("b")).loc(),
+        )
+        .loc(),
         BinaryOp(
             Add,
-            box Name(ast::Name("a")),
-            box BinaryOp(Add, box Name(ast::Name("b")), box Name(ast::Name("c"))),
-        ),
+            box BinaryOp(
+                Add,
+                box Name(ast::Name("a")).loc(),
+                box Name(ast::Name("b")).loc(),
+            )
+            .loc(),
+            box Name(ast::Name("c")).loc(),
+        )
+        .loc(),
+        BinaryOp(
+            Add,
+            box Name(ast::Name("a")).loc(),
+            box BinaryOp(
+                Add,
+                box Name(ast::Name("b")).loc(),
+                box Name(ast::Name("c")).loc(),
+            )
+            .loc(),
+        )
+        .loc(),
     ];
 
     assert_eq!(expected[0], result[0], "simple");
@@ -70,14 +89,18 @@ fn binary_op() -> LangResult<()> {
 }
 
 #[test]
-fn unary_op() -> LangResult<()> {
+fn unary_op() -> LangResult<'static, ()> {
     let input = include_str!("un_op.pj");
-    let result = parse(input)?;
+    let result = parse(input)?.content;
     let expected = vec![
-        UnaryOp(UnOp::Neg, box Name(ast::Name("x"))),
-        UnaryOp(UnOp::Not, box Name(ast::Name("x"))),
-        UnaryOp(UnOp::Not, box UnaryOp(UnOp::Not, box Name(ast::Name("x")))),
-        UnaryOp(UnOp::Not, box Name(ast::Name("x"))),
+        UnaryOp(UnOp::Neg, box Name(ast::Name("x")).loc()).loc(),
+        UnaryOp(UnOp::Not, box Name(ast::Name("x")).loc()).loc(),
+        UnaryOp(
+            UnOp::Not,
+            box UnaryOp(UnOp::Not, box Name(ast::Name("x")).loc()).loc(),
+        )
+        .loc(),
+        UnaryOp(UnOp::Not, box Name(ast::Name("x")).loc()).loc(),
     ];
 
     assert_eq!(expected[0], result[0], "minus");
@@ -88,21 +111,38 @@ fn unary_op() -> LangResult<()> {
 }
 
 #[test]
-fn logic_op() -> LangResult<()> {
+fn logic_op() -> LangResult<'static, ()> {
     let input = include_str!("logic_op.pj");
-    let result = parse(input)?;
+    let result = parse(input)?.content;
     let expected = vec![
-        BinaryOp(And, box Name(ast::Name("a")), box Name(ast::Name("b"))),
-        BinaryOp(
-            Or,
-            box BinaryOp(And, box Name(ast::Name("a")), box Name(ast::Name("b"))),
-            box Name(ast::Name("c")),
-        ),
         BinaryOp(
             And,
-            box Name(ast::Name("a")),
-            box BinaryOp(Or, box Name(ast::Name("b")), box Name(ast::Name("c"))),
-        ),
+            box Name(ast::Name("a")).loc(),
+            box Name(ast::Name("b")).loc(),
+        )
+        .loc(),
+        BinaryOp(
+            Or,
+            box BinaryOp(
+                And,
+                box Name(ast::Name("a")).loc(),
+                box Name(ast::Name("b")).loc(),
+            )
+            .loc(),
+            box Name(ast::Name("c")).loc(),
+        )
+        .loc(),
+        BinaryOp(
+            And,
+            box Name(ast::Name("a")).loc(),
+            box BinaryOp(
+                Or,
+                box Name(ast::Name("b")).loc(),
+                box Name(ast::Name("c")).loc(),
+            )
+            .loc(),
+        )
+        .loc(),
     ];
 
     assert_eq!(expected[0], result[0], "simple");
@@ -112,29 +152,48 @@ fn logic_op() -> LangResult<()> {
 }
 
 #[test]
-fn bit_op() -> LangResult<()> {
+fn bit_op() -> LangResult<'static, ()> {
     let input = include_str!("bit_op.pj");
-    let result = parse(input)?;
+    let result = parse(input)?.content;
     let expected = vec![
-        BinaryOp(BitAnd, box Name(ast::Name("a")), box Name(ast::Name("b"))),
+        BinaryOp(
+            BitAnd,
+            box Name(ast::Name("a")).loc(),
+            box Name(ast::Name("b")).loc(),
+        )
+        .loc(),
         BinaryOp(
             BitXor,
             box BinaryOp(
                 BitOr,
-                box BinaryOp(BitAnd, box Name(ast::Name("a")), box Name(ast::Name("b"))),
-                box Name(ast::Name("c")),
-            ),
-            box Name(ast::Name("d")),
-        ),
+                box BinaryOp(
+                    BitAnd,
+                    box Name(ast::Name("a")).loc(),
+                    box Name(ast::Name("b")).loc(),
+                )
+                .loc(),
+                box Name(ast::Name("c")).loc(),
+            )
+            .loc(),
+            box Name(ast::Name("d")).loc(),
+        )
+        .loc(),
         BinaryOp(
             BitXor,
             box BinaryOp(
                 BitAnd,
-                box Name(ast::Name("a")),
-                box BinaryOp(BitOr, box Name(ast::Name("b")), box Name(ast::Name("c"))),
-            ),
-            box Name(ast::Name("d")),
-        ),
+                box Name(ast::Name("a")).loc(),
+                box BinaryOp(
+                    BitOr,
+                    box Name(ast::Name("b")).loc(),
+                    box Name(ast::Name("c")).loc(),
+                )
+                .loc(),
+            )
+            .loc(),
+            box Name(ast::Name("d")).loc(),
+        )
+        .loc(),
     ];
 
     assert_eq!(expected[0], result[0], "simple");
@@ -144,30 +203,44 @@ fn bit_op() -> LangResult<()> {
 }
 
 #[test]
-fn let_bind() -> LangResult<()> {
+fn let_bind() -> LangResult<'static, ()> {
     let input = include_str!("let_bind.pj");
-    let result = parse(input)?;
+    let result = parse(input)?.content;
     let expected = vec![
-        LetBind(ast::Name("x"), None, box Name(ast::Name("y"))),
+        LetBind(ast::Name("x").loc(), None, box Name(ast::Name("y")).loc()).loc(),
         LetBind(
-            ast::Name("x"),
+            ast::Name("x").loc(),
             None,
-            box BinaryOp(Add, box Name(ast::Name("y")), box Name(ast::Name("z"))),
-        ),
-        LetBind(ast::Name("x"), Some(Ty::Int), box Name(ast::Name("y"))),
+            box BinaryOp(
+                Add,
+                box Name(ast::Name("y")).loc(),
+                box Name(ast::Name("z")).loc(),
+            )
+            .loc(),
+        )
+        .loc(),
         LetBind(
-            ast::Name("foo"),
+            ast::Name("x").loc(),
+            Some(Ty::Int.loc()),
+            box Name(ast::Name("y")).loc(),
+        )
+        .loc(),
+        LetBind(
+            ast::Name("foo").loc(),
             None,
             box FnDef(
                 None,
                 vec![Binding {
                     name: ast::Name("x"),
                     ty: Ty::Int,
-                }],
-                vec![Name(ast::Name("x"))],
+                }
+                .loc()],
+                vec![Name(ast::Name("x")).loc()].loc(),
                 None,
-            ),
-        ),
+            )
+            .loc(),
+        )
+        .loc(),
     ];
 
     assert_eq!(expected[0], result[0], "simple");
@@ -178,20 +251,22 @@ fn let_bind() -> LangResult<()> {
 }
 
 #[test]
-fn cond() -> LangResult<()> {
+fn cond() -> LangResult<'static, ()> {
     let input = include_str!("cond.pj");
-    let result = parse(input)?;
+    let result = parse(input)?.content;
     let expected = vec![
         Cond(
-            vec![Name(ast::Name("x"))],
-            vec![Name(ast::Name("y"))],
-            vec![Name(ast::Name("z"))],
-        ),
+            vec![Name(ast::Name("x")).loc()].loc(),
+            vec![Name(ast::Name("y")).loc()].loc(),
+            vec![Name(ast::Name("z")).loc()].loc(),
+        )
+        .loc(),
         Cond(
-            vec![Name(ast::Name("u")), Name(ast::Name("v"))],
-            vec![Name(ast::Name("w")), Name(ast::Name("x"))],
-            vec![Name(ast::Name("y")), Name(ast::Name("z"))],
-        ),
+            vec![Name(ast::Name("u")).loc(), Name(ast::Name("v")).loc()].loc(),
+            vec![Name(ast::Name("w")).loc(), Name(ast::Name("x")).loc()].loc(),
+            vec![Name(ast::Name("y")).loc(), Name(ast::Name("z")).loc()].loc(),
+        )
+        .loc(),
     ];
 
     assert_eq!(expected[0], result[0], "simple blocks");
@@ -200,16 +275,17 @@ fn cond() -> LangResult<()> {
 }
 
 #[test]
-fn call() -> LangResult<()> {
+fn call() -> LangResult<'static, ()> {
     let input = include_str!("call.pj");
-    let result = parse(input)?;
+    let result = parse(input)?.content;
     let expected = vec![
-        Call(ast::Name("x"), vec![]),
-        Call(ast::Name("x"), vec![Name(ast::Name("y"))]),
+        Call(ast::Name("x").loc(), vec![]).loc(),
+        Call(ast::Name("x").loc(), vec![Name(ast::Name("y")).loc()]).loc(),
         Call(
-            ast::Name("x"),
-            vec![Name(ast::Name("y")), Name(ast::Name("z"))],
-        ),
+            ast::Name("x").loc(),
+            vec![Name(ast::Name("y")).loc(), Name(ast::Name("z")).loc()],
+        )
+        .loc(),
     ];
 
     assert_eq!(expected[0], result[0], "nullary call");
@@ -219,59 +295,69 @@ fn call() -> LangResult<()> {
 }
 
 #[test]
-fn fn_def() -> LangResult<()> {
+fn fn_def() -> LangResult<'static, ()> {
     let input = include_str!("fn_def.pj");
-    let result = parse(input)?;
+    let result = parse(input)?.content;
     let expected = vec![
-        FnDef(Some(ast::Name("foo")), vec![], vec![], None),
+        FnDef(Some(ast::Name("foo").loc()), vec![], vec![].loc(), None).loc(),
         FnDef(
-            Some(ast::Name("foo")),
+            Some(ast::Name("foo").loc()),
             vec![Binding {
                 name: ast::Name("x"),
                 ty: Ty::Int,
-            }],
-            vec![Name(ast::Name("x"))],
+            }
+            .loc()],
+            vec![Name(ast::Name("x")).loc()].loc(),
             None,
-        ),
+        )
+        .loc(),
         FnRecDef(
-            ast::Name("foo"),
+            ast::Name("foo").loc(),
             vec![],
-            vec![Call(ast::Name("foo"), vec![])],
-            Ty::Unit,
-        ),
+            vec![Call(ast::Name("foo").loc(), vec![]).loc()].loc(),
+            Ty::Unit.loc(),
+        )
+        .loc(),
         FnDef(
-            Some(ast::Name("foo")),
+            Some(ast::Name("foo").loc()),
             vec![
                 Binding {
                     name: ast::Name("x"),
                     ty: Ty::Int,
-                },
+                }
+                .loc(),
                 Binding {
                     name: ast::Name("y"),
                     ty: Ty::Int,
-                },
+                }
+                .loc(),
             ],
-            vec![Name(ast::Name("x")), Name(ast::Name("y"))],
+            vec![Name(ast::Name("x")).loc(), Name(ast::Name("y")).loc()].loc(),
             None,
-        ),
+        )
+        .loc(),
         FnDef(
             None,
             vec![Binding {
                 name: ast::Name("x"),
                 ty: Ty::Int,
-            }],
-            vec![Name(ast::Name("x"))],
+            }
+            .loc()],
+            vec![Name(ast::Name("x")).loc()].loc(),
             None,
-        ),
+        )
+        .loc(),
         FnDef(
             None,
             vec![Binding {
                 name: ast::Name("x"),
                 ty: Ty::Int,
-            }],
-            vec![Name(ast::Name("x"))],
+            }
+            .loc()],
+            vec![Name(ast::Name("x")).loc()].loc(),
             None,
-        ),
+        )
+        .loc(),
     ];
 
     assert_eq!(expected[0], result[0], "nullary def");
@@ -284,30 +370,54 @@ fn fn_def() -> LangResult<()> {
 }
 
 #[test]
-fn precedence() -> LangResult<()> {
+fn precedence() -> LangResult<'static, ()> {
     let input = include_str!("precedence.pj");
-    let result = parse(input)?;
+    let result = parse(input)?.content;
     let expected = vec![
         BinaryOp(
             Add,
-            box Name(ast::Name("a")),
-            box BinaryOp(Mul, box Name(ast::Name("b")), box Name(ast::Name("c"))),
-        ),
+            box Name(ast::Name("a")).loc(),
+            box BinaryOp(
+                Mul,
+                box Name(ast::Name("b")).loc(),
+                box Name(ast::Name("c")).loc(),
+            )
+            .loc(),
+        )
+        .loc(),
         BinaryOp(
             BitAnd,
-            box Name(ast::Name("a")),
-            box BinaryOp(Add, box Name(ast::Name("b")), box Name(ast::Name("c"))),
-        ),
+            box Name(ast::Name("a")).loc(),
+            box BinaryOp(
+                Add,
+                box Name(ast::Name("b")).loc(),
+                box Name(ast::Name("c")).loc(),
+            )
+            .loc(),
+        )
+        .loc(),
         BinaryOp(
             Eq,
-            box Name(ast::Name("a")),
-            box BinaryOp(BitAnd, box Name(ast::Name("b")), box Name(ast::Name("c"))),
-        ),
+            box Name(ast::Name("a")).loc(),
+            box BinaryOp(
+                BitAnd,
+                box Name(ast::Name("b")).loc(),
+                box Name(ast::Name("c")).loc(),
+            )
+            .loc(),
+        )
+        .loc(),
         BinaryOp(
             And,
-            box Name(ast::Name("a")),
-            box BinaryOp(Eq, box Name(ast::Name("b")), box Name(ast::Name("c"))),
-        ),
+            box Name(ast::Name("a")).loc(),
+            box BinaryOp(
+                Eq,
+                box Name(ast::Name("b")).loc(),
+                box Name(ast::Name("c")).loc(),
+            )
+            .loc(),
+        )
+        .loc(),
     ];
     assert_eq!(expected[0], result[0], "mul precedes add");
     assert_eq!(expected[1], result[1], "add precedes bitwise and");
@@ -317,29 +427,58 @@ fn precedence() -> LangResult<()> {
 }
 
 #[test]
-fn cmp_and_shift() -> LangResult<()> {
+fn cmp_and_shift() -> LangResult<'static, ()> {
     let input = include_str!("cmp_and_shift.pj");
-    let result = parse(input)?;
+    let result = parse(input)?.content;
     let expected = vec![
         BinaryOp(
             Lt,
-            box BinaryOp(Shl, box Name(ast::Name("a")), box Name(ast::Name("b"))),
-            box BinaryOp(Shl, box Name(ast::Name("c")), box Name(ast::Name("d"))),
-        ),
+            box BinaryOp(
+                Shl,
+                box Name(ast::Name("a")).loc(),
+                box Name(ast::Name("b")).loc(),
+            )
+            .loc(),
+            box BinaryOp(
+                Shl,
+                box Name(ast::Name("c")).loc(),
+                box Name(ast::Name("d")).loc(),
+            )
+            .loc(),
+        )
+        .loc(),
         BinaryOp(
             Gt,
-            box BinaryOp(Shr, box Name(ast::Name("a")), box Name(ast::Name("b"))),
-            box BinaryOp(Shr, box Name(ast::Name("c")), box Name(ast::Name("d"))),
-        ),
+            box BinaryOp(
+                Shr,
+                box Name(ast::Name("a")).loc(),
+                box Name(ast::Name("b")).loc(),
+            )
+            .loc(),
+            box BinaryOp(
+                Shr,
+                box Name(ast::Name("c")).loc(),
+                box Name(ast::Name("d")).loc(),
+            )
+            .loc(),
+        )
+        .loc(),
         BinaryOp(
             Shr,
             box BinaryOp(
                 Shr,
-                box Name(ast::Name("a")),
-                box BinaryOp(Gt, box Name(ast::Name("b")), box Name(ast::Name("c"))),
-            ),
-            box Name(ast::Name("d")),
-        ),
+                box Name(ast::Name("a")).loc(),
+                box BinaryOp(
+                    Gt,
+                    box Name(ast::Name("b")).loc(),
+                    box Name(ast::Name("c")).loc(),
+                )
+                .loc(),
+            )
+            .loc(),
+            box Name(ast::Name("d")).loc(),
+        )
+        .loc(),
     ];
 
     assert_eq!(expected[0], result[0], "left shift");

--- a/tests/type_check/fail/arithmetic/mod.rs
+++ b/tests/type_check/fail/arithmetic/mod.rs
@@ -1,23 +1,25 @@
 use crate::{test_type, test_type_for_all_integer_binops};
+
 use pijama::{
+    ast::Located,
     ty::{Ty, TyError},
     LangError,
 };
 
 test_type!(
     wrong_type_minus,
-    Err(LangError::Ty(TyError::Mismatch {
+    Err(LangError::Ty(TyError::Unexpected {
         expected: Ty::Int,
-        found: Ty::Bool
+        found: Located { content: Ty::Bool, ..}
     }))
 );
 
 // Test all int binary operators with a bool and a int argument
 test_type_for_all_integer_binops!(
     mixed_types_placeholder,
-    Err(LangError::Ty(TyError::Mismatch {
+    Err(LangError::Ty(TyError::Unexpected {
         expected: Ty::Int,
-        found: Ty::Bool
+        found: Located { content: Ty::Bool, ..}
     })),
     OPERATOR
 );
@@ -25,9 +27,9 @@ test_type_for_all_integer_binops!(
 // Test all int binary operators with bool arguments
 test_type_for_all_integer_binops!(
     wrong_type_placeholder,
-    Err(LangError::Ty(TyError::Mismatch {
+    Err(LangError::Ty(TyError::Unexpected {
         expected: Ty::Int,
-        found: Ty::Bool
+        found: Located { content: Ty::Bool, ..}
     })),
     OPERATOR
 );

--- a/tests/type_check/fail/bindings/mod.rs
+++ b/tests/type_check/fail/bindings/mod.rs
@@ -1,13 +1,15 @@
 use crate::test_type;
+
 use pijama::{
+    ast::Located,
     ty::{Ty, TyError},
     LangError,
 };
 
 test_type!(
     bind_bool_to_int,
-    Err(LangError::Ty(TyError::Mismatch {
+    Err(LangError::Ty(TyError::Unexpected {
         expected: Ty::Int,
-        found: Ty::Bool
+        found: Located { content: Ty::Bool, ..}
     }))
 );

--- a/tests/type_check/fail/comparison/mod.rs
+++ b/tests/type_check/fail/comparison/mod.rs
@@ -1,5 +1,7 @@
 use crate::{test_type_for_all_comparision_binops, test_type_for_all_equality_binops};
+
 use pijama::{
+    ast::Located,
     ty::{Ty, TyError},
     LangError,
 };
@@ -7,9 +9,9 @@ use pijama::{
 // Test all int comparison operators with bool arguments
 test_type_for_all_comparision_binops!(
     wrong_type_placeholder,
-    Err(LangError::Ty(TyError::Mismatch {
+    Err(LangError::Ty(TyError::Unexpected {
         expected: Ty::Int,
-        found: Ty::Bool
+        found: Located { content: Ty::Bool, ..}
     })),
     OPERATOR
 );
@@ -17,9 +19,9 @@ test_type_for_all_comparision_binops!(
 // Test all equality operators with int and bool arguments
 test_type_for_all_equality_binops!(
     mixed_type_int_placeholder,
-    Err(LangError::Ty(TyError::Mismatch {
+    Err(LangError::Ty(TyError::Unexpected {
         expected: Ty::Int,
-        found: Ty::Bool
+        found: Located { content: Ty::Bool, ..}
     })),
     OPERATOR
 );
@@ -27,9 +29,9 @@ test_type_for_all_equality_binops!(
 // Test all equality operators with bool and int arguments
 test_type_for_all_equality_binops!(
     mixed_type_bool_placeholder,
-    Err(LangError::Ty(TyError::Mismatch {
+    Err(LangError::Ty(TyError::Unexpected {
         expected: Ty::Bool,
-        found: Ty::Int
+        found: Located { content: Ty::Int, ..}
     })),
     OPERATOR
 );

--- a/tests/type_check/fail/conditionals/mod.rs
+++ b/tests/type_check/fail/conditionals/mod.rs
@@ -1,20 +1,22 @@
 use crate::test_type;
+
 use pijama::{
+    ast::Located,
     ty::{Ty, TyError},
     LangError,
 };
 
 test_type!(
     wrong_type_cond_input,
-    Err(LangError::Ty(TyError::Mismatch {
+    Err(LangError::Ty(TyError::Unexpected {
         expected: Ty::Bool,
-        found: Ty::Int
+        found: Located { content: Ty::Int, ..}
     }))
 );
 test_type!(
     mixed_types_cond_result,
-    Err(LangError::Ty(TyError::Mismatch {
+    Err(LangError::Ty(TyError::Unexpected {
         expected: Ty::Bool,
-        found: Ty::Int
+        found: Located { content: Ty::Int, ..}
     }))
 );

--- a/tests/type_check/fail/functions/mod.rs
+++ b/tests/type_check/fail/functions/mod.rs
@@ -1,37 +1,39 @@
 use crate::test_type;
+
 use pijama::{
+    ast::Located,
     ty::{Ty, TyError},
     LangError,
 };
 
 test_type!(
     wrong_type_fn_call_arg,
-    Err(LangError::Ty(TyError::Mismatch {
+    Err(LangError::Ty(TyError::Unexpected {
         expected: Ty::Int,
-        found: Ty::Bool
+        found: Located { content: Ty::Bool, ..}
     }))
 );
 
 test_type!(
     wrong_return_type_fn_int_to_int,
-    Err(LangError::Ty(TyError::Mismatch {
+    Err(LangError::Ty(TyError::Unexpected {
         expected: Ty::Arrow(box Ty::Int, box Ty::Bool),
-        found: Ty::Arrow(box Ty::Int, box Ty::Int),
+        found: Located { content: Ty::Arrow(box Ty::Int, box Ty::Int), ..}
     }))
 );
 
 test_type!(
     wrong_type_anon_fn_call_arg,
-    Err(LangError::Ty(TyError::Mismatch {
+    Err(LangError::Ty(TyError::Unexpected {
         expected: Ty::Int,
-        found: Ty::Bool
+        found: Located { content: Ty::Bool, ..}
     }))
 );
 
 test_type!(
     wrong_return_type_anon_fn_int_to_int,
-    Err(LangError::Ty(TyError::Mismatch {
+    Err(LangError::Ty(TyError::Unexpected {
         expected: Ty::Arrow(box Ty::Int, box Ty::Bool),
-        found: Ty::Arrow(box Ty::Int, box Ty::Int),
+        found: Located { content: Ty::Arrow(box Ty::Int, box Ty::Int), ..}
     }))
 );

--- a/tests/type_check/fail/logic/mod.rs
+++ b/tests/type_check/fail/logic/mod.rs
@@ -1,5 +1,7 @@
 use crate::{test_type, test_type_for_all_logical_binops};
+
 use pijama::{
+    ast::Located,
     ty::{Ty, TyError},
     LangError,
 };
@@ -7,9 +9,9 @@ use pijama::{
 // Test all logical operators with int arguments
 test_type_for_all_logical_binops!(
     wrong_type_placeholder,
-    Err(LangError::Ty(TyError::Mismatch {
+    Err(LangError::Ty(TyError::Unexpected {
         expected: Ty::Bool,
-        found: Ty::Int
+        found: Located { content: Ty::Int, ..}
     })),
     OPERATOR
 );
@@ -17,9 +19,9 @@ test_type_for_all_logical_binops!(
 // Test all logical operators with bool and int arguments
 test_type_for_all_logical_binops!(
     mixed_type_placeholder_first_is_bool,
-    Err(LangError::Ty(TyError::Mismatch {
+    Err(LangError::Ty(TyError::Unexpected {
         expected: Ty::Bool,
-        found: Ty::Int
+        found: Located { content: Ty::Int, ..}
     })),
     OPERATOR
 );
@@ -27,17 +29,17 @@ test_type_for_all_logical_binops!(
 // Test all logical operators with int and bool arguments
 test_type_for_all_logical_binops!(
     mixed_type_placeholder_second_is_bool,
-    Err(LangError::Ty(TyError::Mismatch {
+    Err(LangError::Ty(TyError::Unexpected {
         expected: Ty::Bool,
-        found: Ty::Int
+        found: Located { content: Ty::Int, ..}
     })),
     OPERATOR
 );
 
 test_type!(
     wrong_type_not,
-    Err(LangError::Ty(TyError::Mismatch {
+    Err(LangError::Ty(TyError::Unexpected {
         expected: Ty::Bool,
-        found: Ty::Int
+        found: Located { content: Ty::Int, ..}
     }))
 );

--- a/tests/type_check/mod.rs
+++ b/tests/type_check/mod.rs
@@ -6,7 +6,7 @@ mod pass;
 fn type_check(input: &str) -> LangResult<Ty> {
     let ast = parser::parse(input)?;
     let mir = mir::Term::from_ast(ast)?;
-    Ok(ty::ty_check(&mir)?)
+    Ok(ty::ty_check(&mir)?.content)
 }
 
 /// Create a test with `$name` that type checks a file with `$name`.pj

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -1,0 +1,16 @@
+use pijama::{
+    ast::{Block, Located, Location, Name, Node},
+    ty::{Binding, Ty},
+};
+
+pub trait DummyLoc: std::fmt::Debug + Sized {
+    fn loc(self) -> Located<Self> {
+        Located::new(self, Location::new(0, 0))
+    }
+}
+
+impl<'a> DummyLoc for Node<'a> {}
+impl DummyLoc for Ty {}
+impl<'a> DummyLoc for Binding<'a> {}
+impl<'a> DummyLoc for Block<'a> {}
+impl<'a> DummyLoc for Name<'a> {}


### PR DESCRIPTION
This PR adds a new `Location` type to the AST in order to track the position of every single `Node`. With this I was able to add nice type errors:
![image](https://user-images.githubusercontent.com/31802960/82408733-db354d80-9a31-11ea-92fb-f9d9c2d830ec.png)
Which means that this issue closes https://github.com/christianpoveda/pijama/issues/10. However there are some things I'd like to fix first:
- [x] In the process I moved the optional typing to the MIR and this ended up breaking the type-checking tests because nameless functions with a return type binding cannot be represented correctly as a term. I ended up adding a new variant for this but it feels like a bunch of duct tape around a pipe. I might end up rolling back that change.
- [x] Even though this doesn't change the grammar of the language, it adds a lot of new things to the parsing module and those need documentation.
- [x] @seanchen1991  and @DarkDrek  are working on other issues and I'd prefer to wait to merge their changes before merging this.