### PR TITLE
Change options in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,15 @@
+sudo: false
+
 language: rust
 rust:
   - nightly
+
+cache: cargo
+
 jobs:
   fast_finish: true
+
+script:
+  - cargo build --verbose
+  - cargo test --verbose
+  - cargo bench --verbose --no-run

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,5 @@ jobs:
   fast_finish: true
 
 script:
-  - cargo build --verbose
+  - cargo build --verbose --all-targets
   - cargo test --verbose
-  - cargo bench --verbose --no-run

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 language: rust
 rust:
   - nightly


### PR DESCRIPTION
Here a opinionated change to the .travis.yml
I just wanted the benchmarks to be at least compiled as check

We don't need sudo
We can cache build results
We can at least try to compile the benchmarks