### PR TITLE
Custom rustfmt config

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,5 @@
+edition = "2018"
+format_code_in_doc_comments = true
+format_macro_matchers = true
+merge_imports = true
+use_field_init_shorthand = true

--- a/benches/eval.rs
+++ b/benches/eval.rs
@@ -2,11 +2,13 @@ use criterion::{criterion_group, criterion_main, Criterion};
 
 use std::include_str;
 
-use pijama::lir::{evaluate, Term};
-use pijama::mir::Term as MirTerm;
-use pijama::parser::parse;
-use pijama::ty::ty_check;
-use pijama::LangResult;
+use pijama::{
+    lir::{evaluate, Term},
+    mir::Term as MirTerm,
+    parser::parse,
+    ty::ty_check,
+    LangResult,
+};
 
 fn compile(input: &str) -> LangResult<Term> {
     let ast = parse(input)?;

--- a/src/lir/ctx.rs
+++ b/src/lir/ctx.rs
@@ -1,6 +1,4 @@
-use crate::ast::Name;
-use crate::lir;
-use crate::mir;
+use crate::{ast::Name, lir, mir};
 
 pub fn remove_names(term: mir::Term<'_>) -> lir::Term {
     Context::default().remove_names(term)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
-use std::env::args;
-use std::fs::read_to_string;
+use std::{env::args, fs::read_to_string};
 
 use pijama::run;
 

--- a/src/mir.rs
+++ b/src/mir.rs
@@ -1,8 +1,10 @@
 use std::fmt;
 
-use crate::ast::*;
-use crate::ty::{expect_ty, ty_check, Binding, Ty, TyResult};
-use crate::{LangError, LangResult};
+use crate::{
+    ast::*,
+    ty::{expect_ty, ty_check, Binding, Ty, TyResult},
+    LangError, LangResult,
+};
 
 #[derive(Debug, Clone)]
 pub enum Term<'a> {

--- a/src/parser/bin_op.rs
+++ b/src/parser/bin_op.rs
@@ -18,8 +18,10 @@ use nom::{
     sequence::terminated,
 };
 
-use crate::ast::BinOp::{self, *};
-use crate::parser::helpers::surrounded;
+use crate::{
+    ast::BinOp::{self, *},
+    parser::helpers::surrounded,
+};
 
 /// Parser for the binary operators with precedence level 1.
 ///

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -29,8 +29,7 @@ use nom::{
 
 use nom::{character::complete::multispace0, combinator::all_consuming};
 
-use crate::ast::Block;
-use crate::{LangError, LangResult};
+use crate::{ast::Block, LangError, LangResult};
 
 use block::block0;
 use helpers::surrounded;

--- a/src/parser/node/binary_op.rs
+++ b/src/parser/node/binary_op.rs
@@ -46,8 +46,10 @@ use nom::{
     sequence::pair,
 };
 
-use crate::ast::Node;
-use crate::parser::{bin_op::*, node::base_node};
+use crate::{
+    ast::Node,
+    parser::{bin_op::*, node::base_node},
+};
 
 /// Parses a [`Node::BinaryOp`].
 pub fn binary_op<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Node, E> {

--- a/src/parser/node/call.rs
+++ b/src/parser/node/call.rs
@@ -10,8 +10,7 @@ use nom::{error::ParseError, IResult};
 
 use nom::{character::complete::space0, combinator::map, sequence::separated_pair};
 
-use crate::ast::Node;
-use crate::parser::name::name;
+use crate::{ast::Node, parser::name::name};
 
 use super::{fn_def::args, node};
 

--- a/src/parser/node/cond.rs
+++ b/src/parser/node/cond.rs
@@ -18,8 +18,10 @@ use nom::{
     sequence::{delimited, pair, terminated, tuple},
 };
 
-use crate::ast::{Block, Node};
-use crate::parser::block::block1;
+use crate::{
+    ast::{Block, Node},
+    parser::block::block1,
+};
 
 /// Parses a [`Node::Cond`].
 ///

--- a/src/parser/node/fn_def.rs
+++ b/src/parser/node/fn_def.rs
@@ -24,12 +24,14 @@ use nom::{
     sequence::{delimited, pair, preceded, terminated, tuple},
 };
 
-use crate::ast::{Block, Name, Node};
-use crate::parser::{
-    block::block0,
-    helpers::{in_brackets, surrounded},
-    name::name,
-    ty::{binding, colon_ty},
+use crate::{
+    ast::{Block, Name, Node},
+    parser::{
+        block::block0,
+        helpers::{in_brackets, surrounded},
+        name::name,
+        ty::{binding, colon_ty},
+    },
 };
 
 /// Parses a [`Node::FnDef`].

--- a/src/parser/node/fn_rec_def.rs
+++ b/src/parser/node/fn_rec_def.rs
@@ -20,11 +20,13 @@ use nom::{
     sequence::{preceded, terminated, tuple},
 };
 
-use crate::ast::{Name, Node};
-use crate::parser::{
-    helpers::surrounded,
-    name::name,
-    ty::{binding, colon_ty},
+use crate::{
+    ast::{Name, Node},
+    parser::{
+        helpers::surrounded,
+        name::name,
+        ty::{binding, colon_ty},
+    },
 };
 
 use super::fn_def::{args, fn_body};

--- a/src/parser/node/let_bind.rs
+++ b/src/parser/node/let_bind.rs
@@ -17,8 +17,10 @@ use nom::{
     sequence::{preceded, tuple},
 };
 
-use crate::ast::Node;
-use crate::parser::{helpers::surrounded, name::name, node::node, ty::colon_ty};
+use crate::{
+    ast::Node,
+    parser::{helpers::surrounded, name::name, node::node, ty::colon_ty},
+};
 
 /// Parses a [`Node::LetBind`].
 ///

--- a/src/parser/node/unary_op.rs
+++ b/src/parser/node/unary_op.rs
@@ -9,8 +9,10 @@ use nom::{error::ParseError, IResult};
 
 use nom::{combinator::map, sequence::pair};
 
-use crate::ast::Node;
-use crate::parser::{node::node, un_op::*};
+use crate::{
+    ast::Node,
+    parser::{node::node, un_op::*},
+};
 
 /// Parses a [`Node::UnaryOp`].
 pub fn unary_op<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Node, E> {

--- a/src/ty/ty_check.rs
+++ b/src/ty/ty_check.rs
@@ -1,8 +1,10 @@
 use thiserror::Error;
 
-use crate::ast::{BinOp, Literal, UnOp};
-use crate::mir::Term;
-use crate::ty::{Binding, Ty};
+use crate::{
+    ast::{BinOp, Literal, UnOp},
+    mir::Term,
+    ty::{Binding, Ty},
+};
 
 pub fn ty_check(term: &Term<'_>) -> TyResult<Ty> {
     Context::default().type_of(term)

--- a/tests/eval/mod.rs
+++ b/tests/eval/mod.rs
@@ -1,9 +1,7 @@
 use std::include_str;
 
 use crate::panic_after;
-use pijama::ast::Literal;
-use pijama::lir::Term;
-use pijama::{run, LangResult};
+use pijama::{ast::Literal, lir::Term, run, LangResult};
 use std::time::Duration;
 
 #[test]

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -3,9 +3,7 @@
 
 extern crate pijama;
 
-use std::sync::mpsc;
-use std::time::Duration;
-use std::{panic, thread};
+use std::{panic, sync::mpsc, thread, time::Duration};
 
 mod eval;
 mod parse;

--- a/tests/parse/mod.rs
+++ b/tests/parse/mod.rs
@@ -1,9 +1,11 @@
 use std::include_str;
 
-use pijama::ast::{self, BinOp::*, Node::*, UnOp};
-use pijama::parser::parse;
-use pijama::ty::{Binding, Ty};
-use pijama::LangResult;
+use pijama::{
+    ast::{self, BinOp::*, Node::*, UnOp},
+    parser::parse,
+    ty::{Binding, Ty},
+    LangResult,
+};
 
 #[test]
 fn name() -> LangResult<()> {

--- a/tests/type_check/fail/arithmetic/mod.rs
+++ b/tests/type_check/fail/arithmetic/mod.rs
@@ -1,6 +1,8 @@
 use crate::{test_type, test_type_for_all_integer_binops};
-use pijama::ty::{Ty, TyError};
-use pijama::LangError;
+use pijama::{
+    ty::{Ty, TyError},
+    LangError,
+};
 
 test_type!(
     wrong_type_minus,

--- a/tests/type_check/fail/bindings/mod.rs
+++ b/tests/type_check/fail/bindings/mod.rs
@@ -1,6 +1,8 @@
 use crate::test_type;
-use pijama::ty::{Ty, TyError};
-use pijama::LangError;
+use pijama::{
+    ty::{Ty, TyError},
+    LangError,
+};
 
 test_type!(
     bind_bool_to_int,

--- a/tests/type_check/fail/comparison/mod.rs
+++ b/tests/type_check/fail/comparison/mod.rs
@@ -1,6 +1,8 @@
 use crate::{test_type_for_all_comparision_binops, test_type_for_all_equality_binops};
-use pijama::ty::{Ty, TyError};
-use pijama::LangError;
+use pijama::{
+    ty::{Ty, TyError},
+    LangError,
+};
 
 // Test all int comparison operators with bool arguments
 test_type_for_all_comparision_binops!(

--- a/tests/type_check/fail/conditionals/mod.rs
+++ b/tests/type_check/fail/conditionals/mod.rs
@@ -1,6 +1,8 @@
 use crate::test_type;
-use pijama::ty::{Ty, TyError};
-use pijama::LangError;
+use pijama::{
+    ty::{Ty, TyError},
+    LangError,
+};
 
 test_type!(
     wrong_type_cond_input,

--- a/tests/type_check/fail/functions/mod.rs
+++ b/tests/type_check/fail/functions/mod.rs
@@ -1,6 +1,8 @@
 use crate::test_type;
-use pijama::ty::{Ty, TyError};
-use pijama::LangError;
+use pijama::{
+    ty::{Ty, TyError},
+    LangError,
+};
 
 test_type!(
     wrong_type_fn_call_arg,

--- a/tests/type_check/fail/logic/mod.rs
+++ b/tests/type_check/fail/logic/mod.rs
@@ -1,6 +1,8 @@
 use crate::{test_type, test_type_for_all_logical_binops};
-use pijama::ty::{Ty, TyError};
-use pijama::LangError;
+use pijama::{
+    ty::{Ty, TyError},
+    LangError,
+};
 
 // Test all logical operators with int arguments
 test_type_for_all_logical_binops!(

--- a/tests/type_check/fail/variables/mod.rs
+++ b/tests/type_check/fail/variables/mod.rs
@@ -1,5 +1,4 @@
 use crate::test_type;
-use pijama::ty::TyError;
-use pijama::LangError;
+use pijama::{ty::TyError, LangError};
 
 test_type!(unbounded, Err(LangError::Ty(TyError::Unbound(_))));

--- a/tests/type_check/mod.rs
+++ b/tests/type_check/mod.rs
@@ -1,5 +1,4 @@
-use pijama::ty::Ty;
-use pijama::{mir, parser, ty, LangResult};
+use pijama::{mir, parser, ty, ty::Ty, LangResult};
 
 mod fail;
 mod pass;


### PR DESCRIPTION
Changes to the config are in the first commit. But here some additional reasoning.

- Set rust edition explicitly
  - Not needed if rustfmt is called via `cargo fmt`
- Format code in docs and macro matchers
  - Doesn't change much now since we don't have code in docs but it will hopefully help if we do
- Merge and format imports
  - This is my absolute favorite option since its bundles imports in a nice tree like format.
  - In my workflow I can just add single use statements and the formatter combines them automagically with the other imports
- Use init shorthand automatically
  - This one usually doesn't hurt.

I'm open for discussing the individual changes.