### PR TITLE
Reorder and reformat imports

### DIFF
--- a/src/lir.rs
+++ b/src/lir.rs
@@ -3,7 +3,6 @@ use std::fmt;
 use crate::ast::*;
 
 use eval::*;
-
 use Term::*;
 
 mod ctx;

--- a/src/lir/eval.rs
+++ b/src/lir/eval.rs
@@ -1,5 +1,7 @@
-use super::Term;
-use crate::ast::{BinOp, Literal, UnOp};
+use crate::{
+    ast::{BinOp, Literal, UnOp},
+    lir::Term,
+};
 
 /// Evaluation step for conditionals (if t1 then t2 else t3)
 #[inline(always)]

--- a/src/parser/bin_op.rs
+++ b/src/parser/bin_op.rs
@@ -8,14 +8,14 @@
 //! convention as here.
 //!
 //! [`binary_op`]: crate::parser::node::binary_op
-use nom::{error::ParseError, IResult};
-
 use nom::{
     branch::alt,
     bytes::complete::tag,
     character::complete::{char, space0},
     combinator::{map, not, peek},
+    error::ParseError,
     sequence::terminated,
+    IResult,
 };
 
 use crate::{

--- a/src/parser/block.rs
+++ b/src/parser/block.rs
@@ -4,17 +4,15 @@
 //!
 //! [`parser`]: crate::parser
 
-use nom::{error::ParseError, IResult};
-
 use nom::{
     character::complete::{line_ending, multispace0},
+    error::ParseError,
     multi::{separated_list, separated_nonempty_list},
     sequence::preceded,
+    IResult,
 };
 
-use crate::ast::Block;
-
-use crate::parser::node::node;
+use crate::{ast::Block, parser::node::node};
 
 /// Parser for [`Block`]s.
 ///

--- a/src/parser/helpers.rs
+++ b/src/parser/helpers.rs
@@ -1,11 +1,11 @@
 //! Miscellaneous helper parsers.
 
-use nom::{error::ParseError, IResult};
-
 use nom::{
     character::complete::{char, multispace0},
     combinator::{cut, peek},
+    error::ParseError,
     sequence::{delimited, preceded},
+    IResult,
 };
 
 /// Helper parser for expressions surrounded by a delimiter.

--- a/src/parser/literal.rs
+++ b/src/parser/literal.rs
@@ -2,14 +2,14 @@
 //!
 //! The entry point for this module is the [`literal`] parser.
 
-use nom::{error::ParseError, IResult};
-
 use nom::{
     branch::alt,
     bytes::complete::tag,
     character::complete::{char, digit1},
     combinator::{map, map_opt, opt},
+    error::ParseError,
     sequence::pair,
+    IResult,
 };
 
 use crate::ast::Literal;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -22,12 +22,12 @@
 //! [ABNF]: https://en.wikipedia.org/wiki/Augmented_Backus–Naur_form
 //! [nom docs]: https://docs.rs/nom/
 use nom::{
+    character::complete::multispace0,
+    combinator::all_consuming,
     error::{convert_error, VerboseError},
     Err::{Error, Failure},
     IResult,
 };
-
-use nom::{character::complete::multispace0, combinator::all_consuming};
 
 use crate::{ast::Block, LangError, LangResult};
 

--- a/src/parser/name.rs
+++ b/src/parser/name.rs
@@ -3,12 +3,12 @@
 //! The entry point for this module is the [`name`] function. Names of variables in Pijama must be
 //! alphabetic `snake-case` strings. Certain keywords such as `fn`, `do` and `end` cannot be names,
 //! such keywords are in the [`KEYWORDS`] constant.
-use nom::{error::ParseError, IResult};
-
 use nom::{
     character::complete::{alpha1, char},
     combinator::{map, recognize, verify},
+    error::ParseError,
     multi::separated_nonempty_list,
+    IResult,
 };
 
 use crate::ast::Name;

--- a/src/parser/node/binary_op.rs
+++ b/src/parser/node/binary_op.rs
@@ -39,11 +39,11 @@
 //! [`ty`]: crate::parser::ty
 //! [`node`]: crate::parser::node::node
 //! [`bin_op`]: crate::parser::bin_op
-use nom::{error::ParseError, IResult};
-
 use nom::{
     combinator::{cut, opt},
+    error::ParseError,
     sequence::pair,
+    IResult,
 };
 
 use crate::{

--- a/src/parser/node/call.rs
+++ b/src/parser/node/call.rs
@@ -6,13 +6,18 @@
 //! ```abnf
 //! call = "name "(" (node ("," node)*)? ")"
 //! ```
-use nom::{error::ParseError, IResult};
+use nom::{
+    character::complete::space0, combinator::map, error::ParseError, sequence::separated_pair,
+    IResult,
+};
 
-use nom::{character::complete::space0, combinator::map, sequence::separated_pair};
-
-use crate::{ast::Node, parser::name::name};
-
-use super::{fn_def::args, node};
+use crate::{
+    ast::Node,
+    parser::{
+        name::name,
+        node::{fn_def::args, node},
+    },
+};
 
 /// Parses a [`Node::Call`].
 ///

--- a/src/parser/node/cond.rs
+++ b/src/parser/node/cond.rs
@@ -9,13 +9,13 @@
 //!
 //! Thus, `else` blocks are optional and are represented as empty [`Block`]s inside the
 //! [`Node::Cond`] variant.
-use nom::{error::ParseError, IResult};
-
 use nom::{
     bytes::complete::tag,
     character::complete::{multispace0, multispace1},
     combinator::{map, opt},
+    error::ParseError,
     sequence::{delimited, pair, terminated, tuple},
+    IResult,
 };
 
 use crate::{

--- a/src/parser/node/fn_def.rs
+++ b/src/parser/node/fn_def.rs
@@ -14,14 +14,14 @@
 //!
 //! [`fn_rec_def`]: super::fn_rec_def
 //! [`call`]: super::call
-use nom::{error::ParseError, IResult};
-
 use nom::{
     bytes::complete::tag,
     character::complete::{char, multispace0, multispace1, space0, space1},
     combinator::{map, opt},
+    error::ParseError,
     multi::separated_list,
     sequence::{delimited, pair, preceded, terminated, tuple},
+    IResult,
 };
 
 use crate::{

--- a/src/parser/node/fn_rec_def.rs
+++ b/src/parser/node/fn_rec_def.rs
@@ -11,13 +11,13 @@
 //! code in this module has the same logic as the one in the [`fn_def`] module.
 //!
 //! [`fn_def`]: super::fn_def
-use nom::{error::ParseError, IResult};
-
 use nom::{
     bytes::complete::tag,
     character::complete::{multispace0, space0, space1},
     combinator::map,
+    error::ParseError,
     sequence::{preceded, terminated, tuple},
+    IResult,
 };
 
 use crate::{
@@ -25,11 +25,10 @@ use crate::{
     parser::{
         helpers::surrounded,
         name::name,
+        node::fn_def::{args, fn_body},
         ty::{binding, colon_ty},
     },
 };
-
-use super::fn_def::{args, fn_body};
 
 /// Parses a [`Node::FnDef`].
 ///

--- a/src/parser/node/let_bind.rs
+++ b/src/parser/node/let_bind.rs
@@ -9,12 +9,12 @@
 //!
 //! Meaning that type bindings are optional.
 
-use nom::{error::ParseError, IResult};
-
 use nom::{
     character::complete::{char, space0},
     combinator::{map, opt},
+    error::ParseError,
     sequence::{preceded, tuple},
+    IResult,
 };
 
 use crate::{

--- a/src/parser/node/mod.rs
+++ b/src/parser/node/mod.rs
@@ -15,23 +15,24 @@ mod fn_rec_def;
 mod let_bind;
 mod unary_op;
 
-use nom::{error::ParseError, IResult};
-
 use nom::{
     branch::alt,
     bytes::complete::tag,
     character::complete::{multispace1, space1},
     combinator::map,
+    error::ParseError,
     sequence::{pair, tuple},
+    IResult,
 };
 
-use crate::ast::Node;
-
-use crate::parser::{
-    helpers::{in_brackets, lookahead},
-    literal::literal,
-    name::name,
-    un_op::un_op,
+use crate::{
+    ast::Node,
+    parser::{
+        helpers::{in_brackets, lookahead},
+        literal::literal,
+        name::name,
+        un_op::un_op,
+    },
 };
 
 /// Parser for [`Node`]s.

--- a/src/parser/node/unary_op.rs
+++ b/src/parser/node/unary_op.rs
@@ -5,9 +5,7 @@
 //!
 //! [`un_op`]: crate::parser::un_op
 
-use nom::{error::ParseError, IResult};
-
-use nom::{combinator::map, sequence::pair};
+use nom::{combinator::map, error::ParseError, sequence::pair, IResult};
 
 use crate::{
     ast::Node,

--- a/src/parser/ty.rs
+++ b/src/parser/ty.rs
@@ -35,21 +35,22 @@
 //! [`Binding`]: crate::ty::Binding
 //! [`name`]: crate::parser::name
 
-use crate::ty::{Binding, Ty};
-
-use nom::{error::ParseError, IResult};
-
 use nom::{
     branch::alt,
     bytes::complete::tag,
     character::complete::{char, space0},
     combinator::{map, opt},
+    error::ParseError,
     sequence::{pair, preceded},
+    IResult,
 };
 
-use crate::parser::{
-    helpers::{in_brackets, surrounded},
-    name::name,
+use crate::{
+    parser::{
+        helpers::{in_brackets, surrounded},
+        name::name,
+    },
+    ty::{Binding, Ty},
 };
 
 /// Parser for all types.

--- a/src/parser/un_op.rs
+++ b/src/parser/un_op.rs
@@ -4,13 +4,13 @@
 //!
 //! [`un_op`]: crate::parser::un_op::un_op
 //! [`unary_op`]: crate::parser::node::unary_op
-use nom::{error::ParseError, IResult};
-
 use nom::{
     branch::alt,
     character::complete::{char, space0},
     combinator::map,
+    error::ParseError,
     sequence::terminated,
+    IResult,
 };
 
 use crate::ast::UnOp::{self, *};

--- a/tests/eval/mod.rs
+++ b/tests/eval/mod.rs
@@ -1,8 +1,8 @@
-use std::include_str;
+use std::{include_str, time::Duration};
+
+use pijama::{ast::Literal, lir::Term, run, LangResult};
 
 use crate::panic_after;
-use pijama::{ast::Literal, lir::Term, run, LangResult};
-use std::time::Duration;
 
 #[test]
 fn arithmetic() -> LangResult<()> {


### PR DESCRIPTION
Follow-up to #52 that reorders some imports and replaces a few `super::` with `create::` paths to allow better formatting

PS: since you were so fast in merging (did't expect that 😄) this comes in another PR