### PR TITLE
Remove inlining and unnecesary boxing

### DIFF
--- a/src/machine/eval.rs
+++ b/src/machine/eval.rs
@@ -12,7 +12,7 @@ impl Machine {
             // Dispatch step for unary operations
             UnaryOp(op, t1) => self.step_un_op(op, t1),
             // Dispatch step for beta reduction
-            App(box Abs(body), arg) => self.step_beta_reduction(body, arg),
+            App(box Abs(box body), box arg) => self.step_beta_reduction(body, arg),
             // Application with unevaluated first term (t1 t2)
             // Evaluate t1.
             App(ref mut t1, _) => (self.step_in_place(t1), term),
@@ -33,7 +33,6 @@ impl Machine {
     }
 
     /// Evaluation step for conditionals (if t1 then t2 else t3)
-    #[inline(always)]
     fn step_conditional(
         &mut self,
         mut t1: Box<Term>,
@@ -57,7 +56,6 @@ impl Machine {
     }
 
     /// Evaluation step for binary operations (t1 op t2)
-    #[inline(always)]
     fn step_bin_op(&mut self, op: BinOp, t1: Box<Term>, t2: Box<Term>) -> (bool, Term) {
         use BinOp::*;
         use Literal::*;
@@ -78,7 +76,6 @@ impl Machine {
     }
 
     /// Evaluation step for unary operations (op t1)
-    #[inline(always)]
     fn step_un_op(&mut self, op: UnOp, mut t1: Box<Term>) -> (bool, Term) {
         // If t1 is a literal, do the operation.
         if let box Term::Lit(lit) = t1 {
@@ -104,8 +101,7 @@ impl Machine {
     }
 
     /// Evaluation step for beta reduction ((λ. body) arg)
-    #[inline(always)]
-    fn step_beta_reduction(&mut self, mut body: Box<Term>, mut arg: Box<Term>) -> (bool, Term) {
+    fn step_beta_reduction(&mut self, mut body: Term, mut arg: Term) -> (bool, Term) {
         // increase the indices of the argument so they can coincide with the indices of the body.
         arg.shift(true, 0);
         // replace the index 0 by the argument inside the body.
@@ -114,7 +110,7 @@ impl Machine {
         // longer exists.
         body.shift(false, 0);
         // return the body
-        (true, *body)
+        (true, body)
     }
 }
 


### PR DESCRIPTION
@DarkDrek I removed inlining and some boxing to see if we got any improvements... we did :D 

The first line in each benchmark is master, the second one is this branch.
```
arithmetic              time:   [22.127 us 22.160 us 22.199 us]
arithmetic              time:   [21.754 us 21.815 us 21.879 us]

logic                   time:   [43.770 us 43.861 us 43.967 us]
logic                   time:   [43.829 us 44.066 us 44.331 us]

factorial               time:   [58.838 us 59.053 us 59.335 us]
factorial               time:   [57.531 us 57.634 us 57.751 us]

factorial_tail          time:   [106.88 us 107.34 us 107.91 us]
factorial_tail          time:   [104.71 us 105.36 us 106.15 us]

fibonacci               time:   [467.35 us 472.34 us 477.74 us]
fibonacci               time:   [463.62 us 467.28 us 471.94 us]

fibonacci_tail          time:   [102.09 us 110.56 us 119.77 us]
fibonacci_tail          time:   [89.807 us 90.149 us 90.520 us]

gcd                     time:   [773.98 us 785.52 us 801.74 us]
gcd                     time:   [767.82 us 782.45 us 805.14 us]

ackermann               time:   [376.92 us 378.56 us 380.26 us]
ackermann               time:   [380.75 us 382.26 us 383.90 us]

calling                 time:   [137.52 us 138.07 us 138.64 us]
calling                 time:   [137.76 us 138.15 us 138.58 us]

complex_calling         time:   [152.93 us 157.37 us 162.48 us]
complex_calling         time:   [148.16 us 148.91 us 149.79 us]

fancy_max               time:   [2.5135 us 2.5955 us 2.6890 us]
fancy_max               time:   [2.2739 us 2.2921 us 2.3101 us]

step                    time:   [1.3812 us 1.4289 us 1.4878 us]
step                    time:   [1.3206 us 1.3249 us 1.3299 us]
```