### PR TITLE
Add context to some errors during parsing

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,29 @@
+name: Pijama's benchmark
+on:
+    push:
+        branches:
+            - master
+
+jobs:
+    benchmark:
+        name: Continuous Benchmark
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - run: rustup toolchain update stable && rustup default stable
+            - name: Run benchmark
+              run: cargo nightly bench -- --output-format bencher | tee output.txt
+            - name: Store benchmark result
+              uses: rhysd/github-action-benchmark@v1.8.0
+              with:
+                  name: Rust Benchmark
+                  tool: 'cargo'
+                  output-file-path: examples/criterion-rs/output.txt
+                  # Use personal access token instead of GITHUB_TOKEN due to https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869/highlight/false
+                  github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
+                  auto-push: true
+                  # Show alert with commit comment on detecting possible performance regression
+                  alert-threshold: '150%'
+                  comment-on-alert: true
+                  fail-on-alert: true
+                  alert-comment-cc-users: '@christianpoveda'

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -19,10 +19,8 @@ jobs:
                   name: Rust Benchmark
                   tool: 'cargo'
                   output-file-path: output.txt
-                  # Use personal access token instead of GITHUB_TOKEN due to https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869/highlight/false
-                  github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
                   auto-push: true
-                  # Show alert with commit comment on detecting possible performance regression
                   alert-threshold: '150%'
                   comment-on-alert: true
                   fail-on-alert: true

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -12,7 +12,7 @@ jobs:
             - uses: actions/checkout@v2
             - run: rustup toolchain update stable && rustup default stable
             - name: Run benchmark
-              run: cargo bench -- --output-format bencher | tee output.txt
+              run: cargo bench --bench eval -- --output-format bencher | tee output.txt
             - name: Store benchmark result
               uses: rhysd/github-action-benchmark@v1.8.0
               with:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -12,13 +12,13 @@ jobs:
             - uses: actions/checkout@v2
             - run: rustup toolchain update stable && rustup default stable
             - name: Run benchmark
-              run: cargo nightly bench -- --output-format bencher | tee output.txt
+              run: cargo bench -- --output-format bencher | tee output.txt
             - name: Store benchmark result
               uses: rhysd/github-action-benchmark@v1.8.0
               with:
                   name: Rust Benchmark
                   tool: 'cargo'
-                  output-file-path: examples/criterion-rs/output.txt
+                  output-file-path: output.txt
                   # Use personal access token instead of GITHUB_TOKEN due to https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869/highlight/false
                   github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
                   auto-push: true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 
 use ast::Location;
 use machine::Machine;
-use parser::ParseError;
+use parser::ParsingError;
 use ty::TyError;
 
 pub type LangResult<'a, T> = Result<T, LangError<'a>>;
@@ -19,11 +19,11 @@ pub enum LangError<'a> {
     #[error("{0}")]
     Ty(#[from] TyError),
     #[error("{0}")]
-    Parse(ParseError<'a>),
+    Parse(ParsingError<'a>),
 }
 
-impl<'a> From<ParseError<'a>> for LangError<'a> {
-    fn from(err: ParseError<'a>) -> Self {
+impl<'a> From<ParsingError<'a>> for LangError<'a> {
+    fn from(err: ParsingError<'a>) -> Self {
         LangError::Parse(err)
     }
 }

--- a/src/parser/bin_op.rs
+++ b/src/parser/bin_op.rs
@@ -25,7 +25,7 @@ use crate::{
 ///
 /// These operators are `&&` and `||`.
 ///
-/// All the binary operators might be surronded by zero or more spaces.
+/// All the binary operators might be surrounded by zero or more spaces.
 pub fn bin_op_1(input: Span) -> IResult<BinOp> {
     surrounded(
         alt((map(tag("&&"), |_| And), map(tag("||"), |_| Or))),
@@ -40,7 +40,7 @@ pub fn bin_op_1(input: Span) -> IResult<BinOp> {
 /// An additional check is done for `<` and `>` to be sure they are not the beginning of the `>>`
 /// and `<<` operators.
 ///
-/// All the binary operators might be surronded by zero or more spaces.
+/// All the binary operators might be surrounded by zero or more spaces.
 pub fn bin_op_2(input: Span) -> IResult<BinOp> {
     surrounded(
         alt((
@@ -62,7 +62,7 @@ pub fn bin_op_2(input: Span) -> IResult<BinOp> {
 /// An additional check is done for `&` and `|` to be sure they are not the beginning of the `&&`
 /// and `||` operators.
 ///
-/// All the binary operators might be surronded by zero or more spaces.
+/// All the binary operators might be surrounded by zero or more spaces.
 pub fn bin_op_3(input: Span) -> IResult<BinOp> {
     surrounded(
         alt((
@@ -80,7 +80,7 @@ pub fn bin_op_3(input: Span) -> IResult<BinOp> {
 ///
 /// These operators are `+` and `-`.
 ///
-/// All the binary operators might be surronded by zero or more spaces.
+/// All the binary operators might be surrounded by zero or more spaces.
 pub fn bin_op_4(input: Span) -> IResult<BinOp> {
     surrounded(
         alt((map(char('+'), |_| Add), map(char('-'), |_| Sub))),
@@ -92,7 +92,7 @@ pub fn bin_op_4(input: Span) -> IResult<BinOp> {
 ///
 /// These operators are `*`, `/` and `%`.
 ///
-/// All the binary operators might be surronded by zero or more spaces.
+/// All the binary operators might be surrounded by zero or more spaces.
 pub fn bin_op_5(input: Span) -> IResult<BinOp> {
     surrounded(
         alt((

--- a/src/parser/bin_op.rs
+++ b/src/parser/bin_op.rs
@@ -18,7 +18,10 @@ use nom::{
 
 use crate::{
     ast::{BinOp, BinOp::*},
-    parser::{helpers::surrounded, IResult, Span},
+    parser::{
+        helpers::{surrounded, with_context},
+        IResult, Span,
+    },
 };
 
 /// Parser for the binary operators with precedence level 1.
@@ -28,7 +31,10 @@ use crate::{
 /// All the binary operators might be surrounded by zero or more spaces.
 pub fn bin_op_1(input: Span) -> IResult<BinOp> {
     surrounded(
-        alt((map(tag("&&"), |_| And), map(tag("||"), |_| Or))),
+        with_context(
+            "Expected logical operator (&&, ||)",
+            alt((map(tag("&&"), |_| And), map(tag("||"), |_| Or))),
+        ),
         space0,
     )(input)
 }
@@ -43,14 +49,17 @@ pub fn bin_op_1(input: Span) -> IResult<BinOp> {
 /// All the binary operators might be surrounded by zero or more spaces.
 pub fn bin_op_2(input: Span) -> IResult<BinOp> {
     surrounded(
-        alt((
-            map(tag("<="), |_| Lte),
-            map(tag(">="), |_| Gte),
-            map(terminated(char('<'), peek(not(char('<')))), |_| Lt),
-            map(terminated(char('>'), peek(not(char('>')))), |_| Gt),
-            map(tag("=="), |_| Eq),
-            map(tag("!="), |_| Neq),
-        )),
+        with_context(
+            "Expected comparision operator (<=, >=, <, >, ==, !=)",
+            alt((
+                map(tag("<="), |_| Lte),
+                map(tag(">="), |_| Gte),
+                map(terminated(char('<'), peek(not(char('<')))), |_| Lt),
+                map(terminated(char('>'), peek(not(char('>')))), |_| Gt),
+                map(tag("=="), |_| Eq),
+                map(tag("!="), |_| Neq),
+            )),
+        ),
         space0,
     )(input)
 }
@@ -65,13 +74,16 @@ pub fn bin_op_2(input: Span) -> IResult<BinOp> {
 /// All the binary operators might be surrounded by zero or more spaces.
 pub fn bin_op_3(input: Span) -> IResult<BinOp> {
     surrounded(
-        alt((
-            map(terminated(char('&'), peek(not(char('&')))), |_| BitAnd),
-            map(terminated(char('|'), peek(not(char('|')))), |_| BitOr),
-            map(char('^'), |_| BitXor),
-            map(tag(">>"), |_| Shr),
-            map(tag("<<"), |_| Shl),
-        )),
+        with_context(
+            "Expected binary operator (&, |, ^, <<, >>)",
+            alt((
+                map(terminated(char('&'), peek(not(char('&')))), |_| BitAnd),
+                map(terminated(char('|'), peek(not(char('|')))), |_| BitOr),
+                map(char('^'), |_| BitXor),
+                map(tag(">>"), |_| Shr),
+                map(tag("<<"), |_| Shl),
+            )),
+        ),
         space0,
     )(input)
 }
@@ -83,7 +95,10 @@ pub fn bin_op_3(input: Span) -> IResult<BinOp> {
 /// All the binary operators might be surrounded by zero or more spaces.
 pub fn bin_op_4(input: Span) -> IResult<BinOp> {
     surrounded(
-        alt((map(char('+'), |_| Add), map(char('-'), |_| Sub))),
+        with_context(
+            "Expected binary operator (+, -)",
+            alt((map(char('+'), |_| Add), map(char('-'), |_| Sub))),
+        ),
         space0,
     )(input)
 }
@@ -95,11 +110,14 @@ pub fn bin_op_4(input: Span) -> IResult<BinOp> {
 /// All the binary operators might be surrounded by zero or more spaces.
 pub fn bin_op_5(input: Span) -> IResult<BinOp> {
     surrounded(
-        alt((
-            map(char('*'), |_| Mul),
-            map(char('/'), |_| Div),
-            map(char('%'), |_| Rem),
-        )),
+        with_context(
+            "Expected binary operator (*, /, %)",
+            alt((
+                map(char('*'), |_| Mul),
+                map(char('/'), |_| Div),
+                map(char('%'), |_| Rem),
+            )),
+        ),
         space0,
     )(input)
 }

--- a/src/parser/helpers.rs
+++ b/src/parser/helpers.rs
@@ -91,10 +91,7 @@ where
 {
     pair(
         keyword(t.clone()),
-        with_context(
-            format!("Space required after keyword {}.", t),
-            multispace1,
-        ),
+        with_context(format!("Space required after keyword {}.", t), multispace1),
     )
 }
 

--- a/src/parser/literal.rs
+++ b/src/parser/literal.rs
@@ -11,7 +11,7 @@ use nom::{
 
 use crate::{
     ast::{Literal, Located, Location},
-    parser::{IResult, Span},
+    parser::{helpers::with_context, IResult, Span},
 };
 
 /// Parses a [`Literal`](crate::ast::Literal).
@@ -22,18 +22,21 @@ use crate::{
 /// The location of this element matches the start and end of the inputs mentioned above inside the
 /// source code.
 pub fn literal(input: Span) -> IResult<Located<Literal>> {
-    alt((
-        map(tag("true"), |span: Span| {
-            Located::new(Literal::Bool(true), span)
-        }),
-        map(tag("false"), |span: Span| {
-            Located::new(Literal::Bool(false), span)
-        }),
-        map(tag("unit"), |span: Span| Located::new(Literal::Unit, span)),
-        map(number, |Located { content, loc }| {
-            Located::new(Literal::Number(content), loc)
-        }),
-    ))(input)
+    with_context(
+        "Expected literal (true, false, unit) or number",
+        alt((
+            map(tag("true"), |span: Span| {
+                Located::new(Literal::Bool(true), span)
+            }),
+            map(tag("false"), |span: Span| {
+                Located::new(Literal::Bool(false), span)
+            }),
+            map(tag("unit"), |span: Span| Located::new(Literal::Unit, span)),
+            map(number, |Located { content, loc }| {
+                Located::new(Literal::Number(content), loc)
+            }),
+        )),
+    )(input)
 }
 
 /// Parses a signed integer.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -23,7 +23,12 @@
 //! [nom docs]: https://docs.rs/nom/
 use thiserror::Error;
 
-use nom::{character::complete::multispace0, combinator::all_consuming, error::ErrorKind, Err::*};
+use nom::{
+    character::complete::multispace0,
+    combinator::all_consuming,
+    error::{ErrorKind, ParseError},
+    Err::*,
+};
 
 use crate::{
     ast::{Block, Located, Location},
@@ -33,7 +38,6 @@ use crate::{
 use crate::LangError::Parse;
 use block::block0;
 use helpers::surrounded;
-use nom::error::ParseError;
 
 mod bin_op;
 mod block;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -30,8 +30,10 @@ use crate::{
     LangResult,
 };
 
+use crate::LangError::Parse;
 use block::block0;
 use helpers::surrounded;
+use nom::error::ParseError;
 
 mod bin_op;
 mod block;
@@ -47,12 +49,12 @@ type Span<'a> = nom_locate::LocatedSpan<&'a str>;
 impl<'a> From<Span<'a>> for Location {
     fn from(span: Span<'a>) -> Self {
         let start = span.location_offset();
-        let end = start + span.fragment().len();
+        let end = start + 1;
         Location { start, end }
     }
 }
 
-type IResult<'a, T> = nom::IResult<Span<'a>, T, (Span<'a>, ErrorKind)>;
+type IResult<'a, T> = nom::IResult<Span<'a>, T, ParsingError<'a>>;
 
 /// Produces a [`Block`] from a string slice.
 ///
@@ -63,18 +65,55 @@ pub fn parse(input: &str) -> LangResult<Located<Block>> {
     let result: IResult<Located<Block>> = all_consuming(surrounded(block0, multispace0))(span);
     match result {
         Ok((_, block)) => Ok(block),
-        Err(Error(e)) | Err(Failure(e)) => Err(ParseError {
-            span: e.0,
-            kind: e.1,
-        }
-        .into()),
+        Err(Error(e)) | Err(Failure(e)) => Err(Parse(e)),
         _ => unreachable!(),
     }
 }
 
 #[derive(Error, Debug, Eq, PartialEq)]
-#[error("Parsing rule `{kind:?}` failed.")]
-pub struct ParseError<'a> {
+#[error("Parsing error: {}", .context.as_ref().unwrap_or(&"Parsing rule `{kind:?}` failed.".to_string()))]
+pub struct ParsingError<'a> {
     pub span: Span<'a>,
     kind: ErrorKind,
+    context: Option<String>,
+}
+
+impl<'a> ParsingError<'a> {
+    pub fn with_context(_: Span<'a>, context: String, other: Self) -> Self {
+        ParsingError {
+            span: other.span,
+            kind: other.kind,
+            context: Some(context),
+        }
+    }
+}
+
+impl<'a> ParseError<Span<'a>> for ParsingError<'a> {
+    fn from_error_kind(span: Span<'a>, kind: ErrorKind) -> Self {
+        ParsingError {
+            span,
+            kind,
+            context: None,
+        }
+    }
+
+    fn append(_: Span<'a>, _: ErrorKind, other: Self) -> Self {
+        other
+    }
+
+    fn from_char(span: Span<'a>, c: char) -> Self {
+        ParsingError {
+            span,
+            kind: ErrorKind::Char,
+            context: Some(format!("Expected character '{}'.", c)),
+        }
+    }
+
+    fn add_context(_: Span<'a>, context: &'static str, other: Self) -> Self {
+        ParsingError {
+            span: other.span,
+            kind: other.kind,
+            context: Some(context.to_string()),
+        }
+    }
 }

--- a/src/parser/node/cond.rs
+++ b/src/parser/node/cond.rs
@@ -10,16 +10,19 @@
 //! Thus, `else` blocks are optional and are represented as empty [`Block`]s inside the
 //! [`Node::Cond`] variant.
 use nom::{
-    bytes::complete::tag,
-    character::complete::{multispace0, multispace1},
+    character::complete::multispace0,
     combinator::map,
-    sequence::{delimited, pair, preceded, tuple},
+    sequence::{delimited, preceded, tuple},
 };
 use nom_locate::position;
 
 use crate::{
     ast::{Block, Located, Location, Node},
-    parser::{block::block1, IResult, Span},
+    parser::{
+        block::block1,
+        helpers::{keyword, keyword_space},
+        IResult, Span,
+    },
 };
 
 /// Parses a [`Node::Cond`].
@@ -35,7 +38,7 @@ pub fn cond(input: Span) -> IResult<Located<Node>> {
             do_block,
             // FIXME: fix optional else block
             else_block,
-            preceded(tag("end"), position),
+            preceded(keyword("end"), position),
         )),
         move |(sp1, if_block, do_block, else_block, sp2)| {
             Located::new(
@@ -53,7 +56,7 @@ pub fn cond(input: Span) -> IResult<Located<Node>> {
 ///
 /// The location of the returned block ignores the `if` and spaces surrounding the block.
 fn if_block(input: Span) -> IResult<Located<Block>> {
-    delimited(pair(tag("if"), multispace1), block1, multispace0)(input)
+    delimited(keyword_space("if"), block1, multispace0)(input)
 }
 
 /// Parses the `do` block of a [`Node::Cond`].
@@ -63,7 +66,7 @@ fn if_block(input: Span) -> IResult<Located<Block>> {
 ///
 /// The location of the returned block ignores the `do` and spaces surrounding the block.
 fn do_block(input: Span) -> IResult<Located<Block>> {
-    delimited(pair(tag("do"), multispace1), block1, multispace0)(input)
+    delimited(keyword_space("do"), block1, multispace0)(input)
 }
 
 /// Parses the `else` block of a [`Node::Cond`].
@@ -73,5 +76,5 @@ fn do_block(input: Span) -> IResult<Located<Block>> {
 ///
 /// The location of the returned block ignores the `else` and spaces surrounding the block.
 fn else_block(input: Span) -> IResult<Located<Block>> {
-    delimited(pair(tag("else"), multispace1), block1, multispace0)(input)
+    delimited(keyword_space("else"), block1, multispace0)(input)
 }

--- a/src/parser/node/fn_def.rs
+++ b/src/parser/node/fn_def.rs
@@ -15,7 +15,6 @@
 //! [`fn_rec_def`]: super::fn_rec_def
 //! [`call`]: super::call
 use nom::{
-    bytes::complete::tag,
     character::complete::{char, multispace0, space0, space1},
     combinator::{map, opt},
     multi::separated_list,
@@ -70,7 +69,7 @@ pub fn fn_def(input: Span) -> IResult<Located<Node>> {
 /// The location of the returned node matches the start of the `fn` and the end of the name.
 fn fn_name(input: Span) -> IResult<Located<Option<Located<Name>>>> {
     map(
-        separated_pair(position, tag("fn"), opt(preceded(space1, name))),
+        separated_pair(position, keyword("fn"), opt(preceded(space1, name))),
         |(span, opt_name)| {
             let mut loc = Location::from(span);
             if let Some(name) = opt_name.as_ref() {

--- a/src/parser/node/fn_def.rs
+++ b/src/parser/node/fn_def.rs
@@ -16,7 +16,7 @@
 //! [`call`]: super::call
 use nom::{
     bytes::complete::tag,
-    character::complete::{char, multispace0, multispace1, space0, space1},
+    character::complete::{char, multispace0, space0, space1},
     combinator::{map, opt},
     multi::separated_list,
     sequence::{delimited, pair, preceded, separated_pair, terminated, tuple},
@@ -27,7 +27,7 @@ use crate::{
     ast::{Block, Located, Location, Name, Node},
     parser::{
         block::block0,
-        helpers::{in_brackets, surrounded},
+        helpers::{in_brackets, keyword, keyword_space, surrounded},
         name::name,
         ty::{binding, colon_ty},
         IResult, Span,
@@ -111,9 +111,9 @@ pub fn args<'a, O: std::fmt::Debug>(
 pub fn fn_body(input: Span) -> IResult<Located<Located<Block>>> {
     map(
         tuple((
-            terminated(position, pair(tag("do"), multispace1)),
+            terminated(position, keyword_space("do")),
             block0,
-            preceded(pair(multispace0, tag("end")), position),
+            preceded(pair(multispace0, keyword("end")), position),
         )),
         |(sp1, content, sp2)| {
             let loc1 = Location::from(sp1);

--- a/src/parser/node/mod.rs
+++ b/src/parser/node/mod.rs
@@ -17,7 +17,7 @@ mod unary_op;
 use nom::{
     branch::alt,
     bytes::complete::tag,
-    character::complete::{multispace1, space1},
+    character::complete::{char, multispace1, space1},
     combinator::map,
     sequence::{pair, tuple},
 };
@@ -60,7 +60,7 @@ pub fn node(input: Span) -> IResult<Located<Node>> {
 fn base_node(input: Span) -> IResult<Located<Node>> {
     alt((
         lookahead(
-            tag("("),
+            char('('),
             alt((
                 call::call,
                 map(in_brackets(node), |Located { mut content, loc }| {

--- a/src/parser/un_op.rs
+++ b/src/parser/un_op.rs
@@ -13,7 +13,7 @@ use nom::{
 
 use crate::{
     ast::{UnOp, UnOp::*},
-    parser::{IResult, Span},
+    parser::{helpers::with_context, IResult, Span},
 };
 
 /// Parser for the unary operators `!` and `-`.
@@ -21,7 +21,10 @@ use crate::{
 /// All the unary operators might be followed by zero or more spaces.
 pub fn un_op(input: Span) -> IResult<UnOp> {
     terminated(
-        alt((map(char('!'), |_| Not), map(char('-'), |_| Neg))),
+        with_context(
+            "Expected unary operator (!, -)",
+            alt((map(char('!'), |_| Not), map(char('-'), |_| Neg))),
+        ),
         space0,
     )(input)
 }


### PR DESCRIPTION
Attempt at #48 

Renamed `ParseError` to `ParsingError` to avoid a naming conflict with nom.
Add context to `ParsingError` with custom formatting.
Add some helper functions to provide semi-automatic context to some parser errors.

The helper function are currently non-generic because it is easier to write and type-debug them but they can be changed later if necessary.

Error examples (the good ones :D):
```
1 │ fn foo(x: Int) doo
  │                  ^ Parsing error: Space required after keyword do.

1 │ fn unit(x: Int) do
  │    ^ Parsing error: Expected character '('.

1 │ fn foo(x: Int) foo
  │                ^ Parsing error: Expected keyword do.
```