### PR TITLE
Fix scoping

### DIFF
--- a/src/ast/location.rs
+++ b/src/ast/location.rs
@@ -12,7 +12,7 @@ pub struct Location {
 }
 
 impl Location {
-    pub fn new(start: usize, end: usize) -> Self {
+    pub const fn new(start: usize, end: usize) -> Self {
         Location { start, end }
     }
 }

--- a/src/ast/location.rs
+++ b/src/ast/location.rs
@@ -3,7 +3,7 @@ use std::fmt::{Debug, Display, Formatter, Result};
 /// Represents a location in the source code file.
 ///
 /// Both the start and end correspond to locations reported by `nom_locate`.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct Location {
     /// Start of the location
     pub start: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ use thiserror::Error;
 
 use ast::Location;
 use machine::Machine;
+use mir::LowerError;
 use parser::ParsingError;
 use ty::TyError;
 
@@ -22,6 +23,8 @@ pub enum LangError<'a> {
     Ty(#[from] TyError),
     #[error("{0}")]
     Parse(ParsingError<'a>),
+    #[error("{0}")]
+    Lower(#[from] LowerError),
 }
 
 impl<'a> From<ParsingError<'a>> for LangError<'a> {
@@ -49,6 +52,7 @@ pub fn display_error<'a>(input: &str, path: &str, error: &LangError<'a>) {
     let (msg, loc) = match &error {
         LangError::Ty(error) => ("Type error", error.loc()),
         LangError::Parse(error) => ("Parsing error", Location::from(error.span)),
+        LangError::Lower(error) => ("Lowering error", error.loc()),
     };
 
     let diagnostic = Diagnostic::error()

--- a/src/parser/node/cond.rs
+++ b/src/parser/node/cond.rs
@@ -4,7 +4,7 @@
 //! rule
 //!
 //! ```abnf
-//! cond = "if" block1 "do" block1 ("elif" block1 "do" block1)* "else" block1? "end"
+//! cond = "if" block1 "do" block1 ("elif" block1 "do" block1)* "else" block1 "end"
 //! ```
 //!
 //! Thus, `elif` blocks are optional and are represented as empty [`Block`]s inside the

--- a/tests/ast/fail/anon_fn_with_ty.pj
+++ b/tests/ast/fail/anon_fn_with_ty.pj
@@ -1,0 +1,1 @@
+fn(x: Int):Int do x end

--- a/tests/ast/fail/mod.rs
+++ b/tests/ast/fail/mod.rs
@@ -1,23 +1,23 @@
-use crate::{test_type, util::DummyLoc};
+use crate::{test_type, util::dummy_loc};
 
-use pijama::{ty::TyError, LangError};
+use pijama::{mir::LowerError, LangError};
 
 test_type!(
     detect_indirect_recursion,
-    Err(LangError::Ty(TyError::Missing(().loc())))
+    Err(LangError::Lower(LowerError::RecWithoutTy(dummy_loc())))
 );
 
 test_type!(
     detect_recursion_after_shadowing,
-    Err(LangError::Ty(TyError::Missing(().loc())))
+    Err(LangError::Lower(LowerError::RecWithoutTy(dummy_loc())))
 );
 
 test_type!(
     detect_recursion_after_shadowing_2,
-    Err(LangError::Ty(TyError::Missing(().loc())))
+    Err(LangError::Lower(LowerError::RecWithoutTy(dummy_loc())))
 );
 
 test_type!(
     detect_recursion_inside_functions,
-    Err(LangError::Ty(TyError::Missing(().loc())))
+    Err(LangError::Lower(LowerError::RecWithoutTy(dummy_loc())))
 );

--- a/tests/ast/pass/binding_persists_whole_block.pj
+++ b/tests/ast/pass/binding_persists_whole_block.pj
@@ -1,0 +1,10 @@
+
+fn foo(x: Int): Int do
+    x + 1
+end
+
+fn bar(x: Int): Int do
+    foo(x)
+end
+
+bar

--- a/tests/ast/pass/mod.rs
+++ b/tests/ast/pass/mod.rs
@@ -13,3 +13,7 @@ test_type!(
     shadowing_is_not_recursion_2,
     Ok(Ty::Arrow(Box::new(Ty::Int), Box::new(Ty::Int)))
 );
+test_type!(
+     binding_persists_whole_block,
+    Ok(Ty::Arrow(Box::new(Ty::Int), Box::new(Ty::Int)))
+);

--- a/tests/type_check/fail/functions/mod.rs
+++ b/tests/type_check/fail/functions/mod.rs
@@ -28,11 +28,3 @@ test_type!(
         found: Ty::Bool.loc()
     }))
 );
-
-test_type!(
-    wrong_return_type_anon_fn_int_to_int,
-    Err(LangError::Ty(TyError::Unexpected {
-        expected: Ty::Arrow(Box::new(Ty::Int), Box::new(Ty::Bool)),
-        found: Ty::Arrow(Box::new(Ty::Int), Box::new(Ty::Int)).loc()
-    }))
-);

--- a/tests/type_check/fail/functions/wrong_return_type_anon_fn_int_to_int.pj
+++ b/tests/type_check/fail/functions/wrong_return_type_anon_fn_int_to_int.pj
@@ -1,1 +1,0 @@
-fn (x: Int): Bool do x end

--- a/tests/type_check/pass/functions/mod.rs
+++ b/tests/type_check/pass/functions/mod.rs
@@ -14,7 +14,3 @@ test_type!(
     anon_fn_from_int_to_int,
     Ok(Ty::Arrow(Box::new(Ty::Int), Box::new(Ty::Int)))
 );
-test_type!(
-    anon_fn_from_int_to_int_with_type,
-    Ok(Ty::Arrow(Box::new(Ty::Int), Box::new(Ty::Int)))
-);

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -2,9 +2,13 @@ use pijama::ast::{Located, Location};
 
 use std::fmt::Debug;
 
+pub const fn dummy_loc() -> Location {
+    Location::new(0, 0)
+}
+
 pub trait DummyLoc: Debug + Sized {
     fn loc(self) -> Located<Self> {
-        Located::new(self, Location::new(0, 0))
+        Located::new(self, dummy_loc())
     }
 }
 


### PR DESCRIPTION
This PR fixes #71. The following changes were made

- Add a new `LetKind` type to the MIR to store the type annotations made by the user and to mark a definition as recursive or not.
- Add a new field with the `LetKind` type to the `Term::Let` variant.
- Remove the `term::Fix` from the MIR. It still exists in the LIR.
- Update the 2 lowering processes to reflect this.
- In particular, lowering from the AST to the MIR has its own error type now: `LowerError`.

The only regression here is that now is impossible to annotate the return type of anonymous functions. So the following code will fail with a `LowerError`
```elixir
fn(x: Int): Int do x end
```
Which is a bit sad but its what we can do with the current state of affairs.

