### PR TITLE
Refactor and document the `ty` module

### DIFF
--- a/src/ast/location.rs
+++ b/src/ast/location.rs
@@ -60,3 +60,11 @@ impl<T: PartialEq + Debug> PartialEq for Located<T> {
         self.content == other.content
     }
 }
+
+impl<T: Clone + Debug> Clone for Located<T> {
+    fn clone(&self) -> Self {
+        Located::new(self.content.clone(), self.loc)
+    }
+}
+
+impl<T: Copy + Debug> Copy for Located<T> {}

--- a/src/mir/lower.rs
+++ b/src/mir/lower.rs
@@ -109,7 +109,7 @@ fn lower_let_bind<'a>(
 
     if let Some(ty) = opt_ty {
         let term_ty = ty_check(&term)?;
-        expect_ty(ty.content, term_ty)?;
+        expect_ty(&ty.content, &term_ty)?;
     }
 
     Ok(Located::new(
@@ -180,7 +180,7 @@ fn lower_fn_def<'a>(
             (false, Some(ty)) => {
                 // Check that the inferred type matches the user type.
                 let term_ty = ty_check(&term)?;
-                expect_ty(ty, term_ty)?;
+                expect_ty(&ty, &term_ty)?;
             }
             // The function is not recursive and does not have a return type
             (false, None) => (),
@@ -200,7 +200,7 @@ fn lower_fn_def<'a>(
     } else if let Some(ty) = opt_ty {
         // Check that the inferred type matches the user type.
         let term_ty = ty_check(&term)?;
-        expect_ty(ty, term_ty)?;
+        expect_ty(&ty, &term_ty)?;
     }
 
     Ok(term)

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -2,11 +2,11 @@ use std::fmt;
 
 use crate::ast::Name;
 
-mod ty_check;
 mod result;
+mod ty_check;
 
-pub use ty_check::{expect_ty, ty_check};
 pub use result::{TyError, TyResult};
+pub use ty_check::{expect_ty, ty_check};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Ty {

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -1,3 +1,8 @@
+//! Types and functions related to Pijama's type system.
+//!
+//! The entry point for this module is the `ty_check` function which takes care of type inference
+//! and checking.
+
 use std::fmt;
 
 use crate::ast::Name;
@@ -8,11 +13,18 @@ mod ty_check;
 pub use result::{TyError, TyResult};
 pub use ty_check::{expect_ty, ty_check};
 
+/// The type of a term.
+///
+/// Each variant here represents the type a term might have.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Ty {
+    /// The type of booleans.
     Bool,
+    /// The type of (signed) integers.
     Int,
+    /// The [unit type](https://en.wikipedia.org/wiki/Unit_type).
     Unit,
+    /// The type of functions between two types.
     Arrow(Box<Ty>, Box<Ty>),
 }
 
@@ -34,6 +46,10 @@ impl fmt::Display for Ty {
     }
 }
 
+/// A type binding.
+///
+/// This represents a binding of a `Name` to a type and is used inside the type checker as the
+/// default way of encoding that a variable has a type in the current scope.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Binding<'a> {
     pub name: Name<'a>,

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -3,8 +3,10 @@ use std::fmt;
 use crate::ast::Name;
 
 mod ty_check;
+mod result;
 
-pub use ty_check::{expect_ty, ty_check, TyError, TyResult};
+pub use ty_check::{expect_ty, ty_check};
+pub use result::{TyError, TyResult};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Ty {

--- a/src/ty/result.rs
+++ b/src/ty/result.rs
@@ -1,0 +1,30 @@
+use thiserror::Error;
+
+use crate::{ty::Ty, ast::{Location, Located}};
+
+pub type TyResult<T = Ty> = Result<T, TyError>;
+
+#[derive(Error, Debug, Eq, PartialEq)]
+pub enum TyError {
+    #[error("Unexpected type: expected {expected}, found {found}")]
+    Unexpected { expected: Ty, found: Located<Ty> },
+    #[error("Name {0} is not bounded")]
+    Unbound(Located<String>),
+    #[error("Unexpected type: expected function, found {0}")]
+    ExpectedFn(Located<Ty>),
+    #[error("Unexpected type: expected a basic type, found {0}")]
+    ExpectedBasic(Located<Ty>),
+    #[error("Missing type: type cannot be inferred")]
+    Missing(Located<()>),
+}
+
+impl TyError {
+    pub fn loc(&self) -> Location {
+        match self {
+            TyError::Unexpected { found, .. } => found.loc,
+            TyError::Unbound(name) => name.loc,
+            TyError::ExpectedBasic(ty) | TyError::ExpectedFn(ty) => ty.loc,
+            TyError::Missing(unit) => unit.loc,
+        }
+    }
+}

--- a/src/ty/result.rs
+++ b/src/ty/result.rs
@@ -1,3 +1,5 @@
+//! Result and error types related to type checking.
+
 use thiserror::Error;
 
 use crate::{
@@ -5,23 +7,33 @@ use crate::{
     ty::Ty,
 };
 
+/// The type returned by methods and functions in this module.
 pub type TyResult<T = Ty> = Result<T, TyError>;
 
+/// A typing error.
+///
+/// Each variant here represents a reason why the type-checker could fail.
 #[derive(Error, Debug, Eq, PartialEq)]
 pub enum TyError {
+    /// Variant used when two types that should be equal are not.
     #[error("Unexpected type: expected {expected}, found {found}")]
     Unexpected { expected: Ty, found: Located<Ty> },
+    /// Variant used when a name has not been binded to any type in the current scope.
     #[error("Name {0} is not bounded")]
     Unbound(Located<String>),
+    /// Variant used when a type was expected to be a `Ty::Arrow` function type.
     #[error("Unexpected type: expected function, found {0}")]
     ExpectedFn(Located<Ty>),
+    /// Variant used when a type was expected to not be a `Ty::Arrow` function type.
     #[error("Unexpected type: expected a basic type, found {0}")]
     ExpectedBasic(Located<Ty>),
+    /// Variant used when a required type annotation is missing.
     #[error("Missing type: type cannot be inferred")]
     Missing(Located<()>),
 }
 
 impl TyError {
+    /// Returns the location of the error.
     pub fn loc(&self) -> Location {
         match self {
             TyError::Unexpected { found, .. } => found.loc,

--- a/src/ty/result.rs
+++ b/src/ty/result.rs
@@ -1,6 +1,9 @@
 use thiserror::Error;
 
-use crate::{ty::Ty, ast::{Location, Located}};
+use crate::{
+    ast::{Located, Location},
+    ty::Ty,
+};
 
 pub type TyResult<T = Ty> = Result<T, TyError>;
 

--- a/src/ty/ty_check.rs
+++ b/src/ty/ty_check.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ast::{BinOp, Literal, Located, Primitive, UnOp},
+    ast::{BinOp, Literal, Located, Location, Name, Primitive, UnOp},
     mir::Term,
     ty::{Binding, Ty, TyError, TyResult},
 };
@@ -34,113 +34,188 @@ struct Context<'a> {
 impl<'a> Context<'a> {
     fn type_of(&mut self, term: &Located<Term<'a>>) -> TyResult<Located<Ty>> {
         let loc = term.loc;
-        let ty = match &term.content {
-            Term::Lit(lit) => match lit {
-                Literal::Unit => Ty::Unit,
-                Literal::Bool(_) => Ty::Bool,
-                Literal::Number(_) => Ty::Int,
-            },
-            Term::Var(name) => self
-                .inner
-                .iter()
-                .find(|bind| bind.name == *name)
-                .ok_or_else(|| TyError::Unbound(Located::new(name.0.to_string(), loc)))?
-                .ty
-                .clone(),
-            Term::Abs(bind, body) => {
-                self.inner.push(bind.clone());
-                let ty = self.type_of(body.as_ref())?.content;
-                self.inner.pop().unwrap();
-                Ty::Arrow(Box::new(bind.ty.clone()), Box::new(ty))
-            }
-            Term::UnaryOp(op, term) => {
-                let ty = self.type_of(term.as_ref())?;
-                match op {
-                    UnOp::Neg => ensure_ty!(Ty::Int, ty)?,
-                    UnOp::Not => ensure_ty!(Ty::Bool, ty)?,
-                }
-            }
+        match &term.content {
+            Term::Lit(lit) => self.type_of_lit(loc, lit),
+            Term::Var(name) => self.type_of_var(loc, name),
+            Term::Abs(bind, body) => self.type_of_abs(loc, bind, body.as_ref()),
+            Term::UnaryOp(op, term) => self.type_of_unary_op(loc, *op, term.as_ref()),
             Term::BinaryOp(op, t1, t2) => {
-                let ty1 = self.type_of(t1.as_ref())?;
-                let ty2 = self.type_of(t2.as_ref())?;
-                match op {
-                    BinOp::Add
-                    | BinOp::Sub
-                    | BinOp::Mul
-                    | BinOp::Div
-                    | BinOp::Rem
-                    | BinOp::BitAnd
-                    | BinOp::BitOr
-                    | BinOp::BitXor
-                    | BinOp::Shr
-                    | BinOp::Shl => ensure_ty!(Ty::Int, ty1, ty2)?,
-                    BinOp::Or | BinOp::And => ensure_ty!(Ty::Bool, ty1, ty2)?,
-                    BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte => {
-                        ensure_ty!(Ty::Int, ty1, ty2)?;
-                        Ty::Bool
-                    }
-                    BinOp::Eq | BinOp::Neq => {
-                        ensure_ty!(ty1.content, ty2)?;
-                        Ty::Bool
-                    }
-                }
+                self.type_of_binary_op(loc, *op, t1.as_ref(), t2.as_ref())
             }
-            Term::App(t1, t2) => {
-                if let Term::PrimFn(primitive) = t1.content {
-                    self.type_of_primitive(primitive, t2)
-                } else {
-                    let ty1 = self.type_of(t1.as_ref())?;
-                    let ty2 = self.type_of(t2.as_ref())?;
-                    match ty1.content {
-                        Ty::Arrow(ty11, ty) => {
-                            ensure_ty!(*ty11, ty2)?;
-                            *ty
-                        }
-                        _ => return Err(TyError::ExpectedFn(ty1)),
-                    }
-                }
-            }
-            Term::Let(name, t1, t2) => {
-                let bind = self.type_of(t1.as_ref()).map(|ty| Binding {
-                    name: name.content,
-                    ty: ty.content,
-                })?;
-                self.inner.push(bind);
-                let ty2 = self.type_of(t2.as_ref())?;
-                self.inner.pop().unwrap();
-                ty2.content
-            }
-            Term::Cond(t1, t2, t3) => {
-                let ty1 = self.type_of(t1.as_ref())?;
-                let ty2 = self.type_of(t2.as_ref())?;
-                let ty3 = self.type_of(t3.as_ref())?;
-                ensure_ty!(Ty::Bool, ty1)?;
-                ensure_ty!(ty2.content, ty3)?
-            }
-            Term::Seq(t1, t2) => {
-                let ty1 = self.type_of(t1.as_ref())?;
-                ensure_ty!(Ty::Unit, ty1)?;
-                return self.type_of(t2.as_ref());
-            }
-            Term::Fix(t1) => {
-                let ty = self.type_of(t1.as_ref())?;
-                if let Ty::Arrow(ty1, ty2) = ty.content {
-                    ensure_ty!(*ty1, Located::new(*ty2, ty.loc))?
-                } else {
-                    return Err(TyError::ExpectedFn(ty));
-                }
-            }
+            Term::App(t1, t2) => self.type_of_app(loc, t1.as_ref(), t2.as_ref()),
+            Term::Let(name, t1, t2) => self.type_of_let(loc, name, t1.as_ref(), t2.as_ref()),
+            Term::Cond(t1, t2, t3) => self.type_of_cond(loc, t1.as_ref(), t2.as_ref(), t3.as_ref()),
+            Term::Seq(t1, t2) => self.type_of_seq(loc, t1.as_ref(), t2.as_ref()),
+            Term::Fix(t1) => self.type_of_fix(loc, t1.as_ref()),
             Term::PrimFn(prim) => unreachable!(
                 "Primitives always need special case handling but got {:?}",
                 prim
             ),
+        }
+    }
+
+    fn type_of_lit(&mut self, loc: Location, lit: &Literal) -> TyResult<Located<Ty>> {
+        let ty = match lit {
+            Literal::Unit => Ty::Unit,
+            Literal::Bool(_) => Ty::Bool,
+            Literal::Number(_) => Ty::Int,
         };
         Ok(Located::new(ty, loc))
     }
 
-    fn type_of_primitive(&mut self, primitive: Primitive, _arg: &Located<Term>) -> Ty {
-        match primitive {
-            Primitive::Print => Ty::Unit,
+    fn type_of_var(&mut self, loc: Location, name: &Name<'a>) -> TyResult<Located<Ty>> {
+        let ty = self
+            .inner
+            .iter()
+            .find(|bind| bind.name == *name)
+            .ok_or_else(|| TyError::Unbound(Located::new(name.0.to_string(), loc)))?
+            .ty
+            .clone();
+        Ok(Located::new(ty, loc))
+    }
+
+    fn type_of_abs(
+        &mut self,
+        loc: Location,
+        bind: &Binding<'a>,
+        body: &Located<Term<'a>>,
+    ) -> TyResult<Located<Ty>> {
+        self.inner.push(bind.clone());
+        let ty = self.type_of(body)?.content;
+        self.inner.pop().unwrap();
+        let ty = Ty::Arrow(Box::new(bind.ty.clone()), Box::new(ty));
+        Ok(Located::new(ty, loc))
+    }
+
+    fn type_of_unary_op(
+        &mut self,
+        loc: Location,
+        op: UnOp,
+        term: &Located<Term<'a>>,
+    ) -> TyResult<Located<Ty>> {
+        let ty = self.type_of(term)?;
+        let ty = match op {
+            UnOp::Neg => ensure_ty!(Ty::Int, ty)?,
+            UnOp::Not => ensure_ty!(Ty::Bool, ty)?,
+        };
+        Ok(Located::new(ty, loc))
+    }
+
+    fn type_of_binary_op(
+        &mut self,
+        loc: Location,
+        op: BinOp,
+        t1: &Located<Term<'a>>,
+        t2: &Located<Term<'a>>,
+    ) -> TyResult<Located<Ty>> {
+        let ty1 = self.type_of(t1)?;
+        let ty2 = self.type_of(t2)?;
+        let ty = match op {
+            BinOp::Add
+            | BinOp::Sub
+            | BinOp::Mul
+            | BinOp::Div
+            | BinOp::Rem
+            | BinOp::BitAnd
+            | BinOp::BitOr
+            | BinOp::BitXor
+            | BinOp::Shr
+            | BinOp::Shl => ensure_ty!(Ty::Int, ty1, ty2)?,
+            BinOp::Or | BinOp::And => ensure_ty!(Ty::Bool, ty1, ty2)?,
+            BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte => {
+                ensure_ty!(Ty::Int, ty1, ty2)?;
+                Ty::Bool
+            }
+            BinOp::Eq | BinOp::Neq => {
+                ensure_ty!(ty1.content, ty2)?;
+                Ty::Bool
+            }
+        };
+        Ok(Located::new(ty, loc))
+    }
+
+    fn type_of_app(
+        &mut self,
+        loc: Location,
+        t1: &Located<Term<'a>>,
+        t2: &Located<Term<'a>>,
+    ) -> TyResult<Located<Ty>> {
+        if let Term::PrimFn(primitive) = t1.content {
+            self.type_of_primitive(loc, primitive, t2)
+        } else {
+            let ty1 = self.type_of(t1)?;
+            let ty2 = self.type_of(t2)?;
+            match ty1.content {
+                Ty::Arrow(ty11, ty) => {
+                    ensure_ty!(*ty11, ty2)?;
+                    Ok(Located::new(*ty, loc))
+                }
+                _ => Err(TyError::ExpectedFn(ty1)),
+            }
+        }
+    }
+
+    fn type_of_let(
+        &mut self,
+        loc: Location,
+        name: &Located<Name<'a>>,
+        t1: &Located<Term<'a>>,
+        t2: &Located<Term<'a>>,
+    ) -> TyResult<Located<Ty>> {
+        let bind = self.type_of(t1).map(|ty| Binding {
+            name: name.content,
+            ty: ty.content,
+        })?;
+        self.inner.push(bind);
+        let ty2 = self.type_of(t2)?;
+        self.inner.pop().unwrap();
+        Ok(Located::new(ty2.content, loc))
+    }
+
+    fn type_of_cond(
+        &mut self,
+        loc: Location,
+        t1: &Located<Term<'a>>,
+        t2: &Located<Term<'a>>,
+        t3: &Located<Term<'a>>,
+    ) -> TyResult<Located<Ty>> {
+        let ty1 = self.type_of(t1)?;
+        let ty2 = self.type_of(t2)?;
+        let ty3 = self.type_of(t3)?;
+        ensure_ty!(Ty::Bool, ty1)?;
+        let ty = ensure_ty!(ty2.content, ty3)?;
+        Ok(Located::new(ty, loc))
+    }
+
+    fn type_of_seq(
+        &mut self,
+        _loc: Location,
+        t1: &Located<Term<'a>>,
+        t2: &Located<Term<'a>>,
+    ) -> TyResult<Located<Ty>> {
+        let ty1 = self.type_of(t1)?;
+        ensure_ty!(Ty::Unit, ty1)?;
+        self.type_of(t2)
+    }
+
+    fn type_of_fix(&mut self, loc: Location, t1: &Located<Term<'a>>) -> TyResult<Located<Ty>> {
+        let ty = self.type_of(t1)?;
+        if let Ty::Arrow(ty1, ty2) = ty.content {
+            let ty = ensure_ty!(*ty1, Located::new(*ty2, ty.loc))?;
+            Ok(Located::new(ty, loc))
+        } else {
+            Err(TyError::ExpectedFn(ty))
+        }
+    }
+
+    fn type_of_prim_app(
+        &mut self,
+        loc: Location,
+        prim: Primitive,
+        _arg: &Located<Term>,
+    ) -> TyResult<Located<Ty>> {
+        match prim {
+            Primitive::Print => Ok(Located::new(Ty::Unit, loc)),
         }
     }
 }

--- a/src/ty/ty_check.rs
+++ b/src/ty/ty_check.rs
@@ -1,9 +1,7 @@
-use thiserror::Error;
-
 use crate::{
-    ast::{BinOp, Literal, Located, Location, Primitive, UnOp},
+    ast::{BinOp, Literal, Located, Primitive, UnOp},
     mir::Term,
-    ty::{Binding, Ty},
+    ty::{Binding, Ty, TyError, TyResult},
 };
 
 pub fn ty_check(term: &Located<Term<'_>>) -> TyResult<Located<Ty>> {
@@ -27,33 +25,6 @@ macro_rules! ensure_ty {
         crate::ty::expect_ty($expected, $found)$(.and_then(|_| crate::ty::expect_ty($expected, $other)))*
     };
 }
-
-#[derive(Error, Debug, Eq, PartialEq)]
-pub enum TyError {
-    #[error("Unexpected type: expected {expected}, found {found}")]
-    Unexpected { expected: Ty, found: Located<Ty> },
-    #[error("Name {0} is not bounded")]
-    Unbound(Located<String>),
-    #[error("Unexpected type: expected function, found {0}")]
-    ExpectedFn(Located<Ty>),
-    #[error("Unexpected type: expected a basic type, found {0}")]
-    ExpectedBasic(Located<Ty>),
-    #[error("Missing type: type cannot be inferred")]
-    Missing(Located<()>),
-}
-
-impl TyError {
-    pub fn loc(&self) -> Location {
-        match self {
-            TyError::Unexpected { found, .. } => found.loc,
-            TyError::Unbound(name) => name.loc,
-            TyError::ExpectedBasic(ty) | TyError::ExpectedFn(ty) => ty.loc,
-            TyError::Missing(unit) => unit.loc,
-        }
-    }
-}
-
-pub type TyResult<T = Ty> = Result<T, TyError>;
 
 #[derive(Default)]
 struct Context<'a> {


### PR DESCRIPTION
This PR reorganizes the methods inside the `ty::ty_check` module and adds documentation to the whole `ty` module.