### PR TITLE
Use i64 instead of i128

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -87,11 +87,11 @@ impl<'a> Display for UnOp {
 pub enum Literal {
     Bool(bool),
     Unit,
-    Number(i128),
+    Number(i64),
 }
 
-impl From<i128> for Literal {
-    fn from(n: i128) -> Self {
+impl From<i64> for Literal {
+    fn from(n: i64) -> Self {
         Literal::Number(n)
     }
 }

--- a/src/parser/literal.rs
+++ b/src/parser/literal.rs
@@ -41,16 +41,16 @@ pub fn literal(input: Span) -> IResult<Located<Literal>> {
 
 /// Parses a signed integer.
 ///
-/// This integer must be in the valid range for the `i128` type. If the number is outside this
+/// This integer must be in the valid range for the `i64` type. If the number is outside this
 /// range, the parser will return an error.
 ///
 /// If the number is negative, there cannot be spaces between the minus sign and the digits of the
 /// number. That kind of expression will be parsed as an unary operation.
-fn number(input: Span) -> IResult<Located<i128>> {
+fn number(input: Span) -> IResult<Located<i64>> {
     map_opt(
         pair(opt(char('-')), digit1),
         |(sign, digits_span): (Option<char>, Span)| {
-            let mut number = digits_span.fragment().parse::<i128>().ok()?;
+            let mut number = digits_span.fragment().parse::<i64>().ok()?;
             let mut loc: Location = digits_span.into();
 
             if sign.is_some() {


### PR DESCRIPTION
Implement changes proposed in #80 

No big changes in performance but some small wins overall.
```
factorial               time:   [78.238 us 78.869 us 79.569 us]
                        change: [+3.6405% +5.1378% +6.7928%] (p = 0.00 < 0.05)
factorial_tail          time:   [141.26 us 142.99 us 144.96 us]
                        change: [-11.554% -9.3562% -6.6799%] (p = 0.00 < 0.05)
fibonacci_tail          time:   [117.14 us 118.33 us 119.64 us]
                        change: [-12.308% -10.551% -8.6768%] (p = 0.00 < 0.05)
gcd                     time:   [791.76 us 798.09 us 805.03 us]
                        change: [-13.816% -12.259% -10.773%] (p = 0.00 < 0.05)
```