### PR TITLE
Use i64 for all literals in lir

### DIFF
--- a/src/lir/lower.rs
+++ b/src/lir/lower.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ast::{Literal, Located, Name},
+    ast::{Located, Name},
     lir::Term,
     mir::{LetKind, Term as MirTerm},
 };
@@ -16,9 +16,7 @@ struct Context<'a> {
 impl<'a> Context<'a> {
     fn remove_names(&mut self, term: MirTerm<'a>) -> Term {
         match term {
-            MirTerm::Lit(Literal::Number(n)) => Term::Lit(n),
-            MirTerm::Lit(Literal::Bool(b)) => Term::Lit(b.into()),
-            MirTerm::Lit(Literal::Unit) => Term::Lit(0),
+            MirTerm::Lit(lit) => lit.into(),
             MirTerm::Var(name) => {
                 let (index, _) = self
                     .inner

--- a/src/lir/lower.rs
+++ b/src/lir/lower.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ast::{Located, Name},
+    ast::{Literal, Located, Name},
     lir::Term,
     mir::{LetKind, Term as MirTerm},
 };
@@ -16,7 +16,9 @@ struct Context<'a> {
 impl<'a> Context<'a> {
     fn remove_names(&mut self, term: MirTerm<'a>) -> Term {
         match term {
-            MirTerm::Lit(literal) => Term::Lit(literal),
+            MirTerm::Lit(Literal::Number(n)) => Term::Lit(n),
+            MirTerm::Lit(Literal::Bool(b)) => Term::Lit(b.into()),
+            MirTerm::Lit(Literal::Unit) => Term::Lit(0),
             MirTerm::Var(name) => {
                 let (index, _) = self
                     .inner

--- a/src/lir/mod.rs
+++ b/src/lir/mod.rs
@@ -20,6 +20,44 @@ pub enum Term {
     Hole,
 }
 
+impl Term {
+    pub fn as_bool(&self) -> bool {
+        match self {
+            Lit(0) => false,
+            Lit(1) => true,
+            _ => panic!("Non-boolean literal {}", self),
+        }
+    }
+}
+
+impl From<Literal> for Term {
+    fn from(l: Literal) -> Self {
+        match l {
+            Literal::Bool(b) => b.into(),
+            Literal::Unit => ().into(),
+            Literal::Number(n) => n.into(),
+        }
+    }
+}
+
+impl From<i64> for Term {
+    fn from(i: i64) -> Self {
+        Lit(i)
+    }
+}
+
+impl From<bool> for Term {
+    fn from(b: bool) -> Self {
+        Lit(b.into())
+    }
+}
+
+impl From<()> for Term {
+    fn from(_: ()) -> Self {
+        Lit(0)
+    }
+}
+
 impl fmt::Display for Term {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {

--- a/src/lir/mod.rs
+++ b/src/lir/mod.rs
@@ -9,7 +9,7 @@ mod lower;
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Term {
     Var(usize),
-    Lit(Literal),
+    Lit(i64),
     Abs(Box<Term>),
     UnaryOp(UnOp, Box<Term>),
     BinaryOp(BinOp, Box<Term>, Box<Term>),

--- a/src/machine/eval.rs
+++ b/src/machine/eval.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ast::{BinOp, Literal, Primitive, UnOp},
+    ast::{BinOp, Primitive, UnOp},
     lir::Term::{self, *},
     machine::Machine,
 };
@@ -51,9 +51,9 @@ impl<W: Write> Machine<W> {
         if let Term::Lit(lit) = t1.borrow() {
             match lit {
                 // If t1 is true, evaluate to t2.
-                Literal::Bool(true) => (true, *t2),
+                1 => (true, *t2),
                 // If t1 is false, evaluate to t3.
-                Literal::Bool(false) => (true, *t3),
+                0 => (true, *t3),
                 // If t1 is any other literal, panic
                 lit => panic!("Found non-boolean literal {} in condition", lit),
             }
@@ -66,14 +66,14 @@ impl<W: Write> Machine<W> {
     /// Evaluation step for binary operations (t1 op t2)
     fn step_bin_op(&mut self, op: BinOp, mut a: Box<Term>, mut b: Box<Term>) -> (bool, Term) {
         use BinOp::*;
-        use Literal::*;
 
         match (op, a.borrow(), b.borrow()) {
-            (_, Lit(l1), Lit(l2)) => (true, Lit(native_bin_op(op, *l1, *l2))),
             // If op is && and t1 is false evaluate to false
-            (And, Lit(Bool(false)), _) => (true, Lit(Bool(false))),
+            (And, Lit(0), _) => (true, Lit(0)),
             // If op is || and t1 is true evaluate to true
-            (Or, Lit(Bool(true)), _) => (true, Lit(Bool(true))),
+            (Or, Lit(1), _) => (true, Lit(1)),
+            // If both are literals evaluate with native operation
+            (_, Lit(l1), Lit(l2)) => (true, Lit(native_bin_op(op, *l1, *l2))),
             // If t2 is not a literal, evaluate it.
             (_, Lit(_), _) => (self.step_in_place(b.borrow_mut()), Term::BinaryOp(op, a, b)),
             // If t1 is not a literal, evaluate it.
@@ -123,46 +123,42 @@ impl<W: Write> Machine<W> {
         match prim {
             Primitive::Print => {
                 writeln!(self.env.stdout, "{}", arg).expect("Primitive print failed");
-                (true, Term::Lit(Literal::Unit))
+                (true, Term::Lit(0))
             }
         }
     }
 }
 
-fn native_bin_op(op: BinOp, l1: Literal, l2: Literal) -> Literal {
+fn native_bin_op(op: BinOp, n1: i64, n2: i64) -> i64 {
     use BinOp::*;
-    use Literal::*;
 
-    match (op, l1, l2) {
-        (Add, Number(n1), Number(n2)) => (n1 + n2).into(),
-        (Sub, Number(n1), Number(n2)) => (n1 - n2).into(),
-        (Mul, Number(n1), Number(n2)) => (n1 * n2).into(),
-        (Div, Number(n1), Number(n2)) => (n1 / n2).into(),
-        (Rem, Number(n1), Number(n2)) => (n1 % n2).into(),
-        (Lt, Number(n1), Number(n2)) => (n1 < n2).into(),
-        (Lte, Number(n1), Number(n2)) => (n1 <= n2).into(),
-        (Gt, Number(n1), Number(n2)) => (n1 > n2).into(),
-        (Gte, Number(n1), Number(n2)) => (n1 >= n2).into(),
-        (Eq, l1, l2) => (l1 == l2).into(),
-        (Neq, l1, l2) => (l1 != l2).into(),
-        (And, Bool(b1), Bool(b2)) => (b1 && b2).into(),
-        (Or, Bool(b1), Bool(b2)) => (b1 || b2).into(),
-        (BitAnd, Number(n1), Number(n2)) => (n1 & n2).into(),
-        (BitOr, Number(n1), Number(n2)) => (n1 | n2).into(),
-        (BitXor, Number(n1), Number(n2)) => (n1 ^ n2).into(),
-        (Shr, Number(n1), Number(n2)) => (n1 >> n2).into(),
-        (Shl, Number(n1), Number(n2)) => (n1 << n2).into(),
-        (op, l1, l2) => panic!("Unexpected operation `{} {} {}`", l1, op, l2),
+    match op {
+        Add => n1 + n2,
+        Sub => n1 - n2,
+        Mul => n1 * n2,
+        Div => n1 / n2,
+        Rem => n1 % n2,
+        Lt => (n1 < n2).into(),
+        Lte => (n1 <= n2).into(),
+        Gt => (n1 > n2).into(),
+        Gte => (n1 >= n2).into(),
+        Eq => (n1 == n2).into(),
+        Neq => (n1 != n2).into(),
+        And => (n1 == 1 && n2 == 1).into(),
+        Or => (n1 == 1 || n2 == 1).into(),
+        BitAnd => n1 & n2,
+        BitOr => n1 | n2,
+        BitXor => n1 ^ n2,
+        Shr => n1 >> n2,
+        Shl => n1 << n2,
     }
 }
 
-fn native_un_op(op: UnOp, lit: Literal) -> Literal {
-    use Literal::*;
+fn native_un_op(op: UnOp, n: i64) -> i64 {
     use UnOp::*;
 
-    match (op, lit) {
-        (Neg, Number(n)) => (-n).into(),
-        (Not, Bool(b)) => (!b).into(),
-        (op, lit) => panic!("Unexpected operation `{} {}`", op, lit),
+    match op {
+        Neg => -n,
+        Not => !n
     }
 }

--- a/src/mir/lower.rs
+++ b/src/mir/lower.rs
@@ -61,7 +61,7 @@ pub fn lower_blk<'a>(blk: Located<Block<'a>>) -> LowerResult<Located<Term<'a>>> 
 
 fn lower_node(node: Located<Node<'_>>) -> LowerResult<Located<Term<'_>>> {
     let loc = node.loc;
-    let term = match node.content {
+    match node.content {
         Node::Name(name) => Ok(Located::new(Term::Var(name), loc)),
         Node::Cond(if_branch, branches, el_blk) => lower_cond(loc, if_branch, branches, el_blk),
         Node::Literal(lit) => Ok(Located::new(Term::Lit(lit), loc)),
@@ -73,8 +73,7 @@ fn lower_node(node: Located<Node<'_>>) -> LowerResult<Located<Term<'_>>> {
             lower_fn_def(loc, opt_name, binds, body, opt_ty)
         }
         Node::PrimFn(prim) => Ok(Located::new(Term::PrimFn(prim), loc)),
-    }?;
-    Ok(term)
+    }
 }
 
 fn lower_cond<'a>(

--- a/tests/eval/mod.rs
+++ b/tests/eval/mod.rs
@@ -1,7 +1,6 @@
 use std::{include_str, time::Duration};
 
 use pijama::{
-    ast::Literal,
     lir::Term,
     machine::{LangEnv, Machine},
     run, run_with_machine, LangError, LangResult,
@@ -13,7 +12,7 @@ use crate::panic_after;
 fn arithmetic() -> LangResult<'static, ()> {
     let input = include_str!("arithmetic.pj");
     let term = run(input)?;
-    assert_eq!(Term::Lit(Literal::Number(121)), term);
+    assert_eq!(Term::Lit(121), term);
     Ok(())
 }
 
@@ -21,7 +20,7 @@ fn arithmetic() -> LangResult<'static, ()> {
 fn logic() -> LangResult<'static, ()> {
     let input = include_str!("logic.pj");
     let term = run(input)?;
-    assert_eq!(Term::Lit(Literal::Bool(false)), term);
+    assert_eq!(Term::Lit(0), term);
     Ok(())
 }
 
@@ -29,7 +28,7 @@ fn logic() -> LangResult<'static, ()> {
 fn factorial() -> LangResult<'static, ()> {
     let input = include_str!("factorial.pj");
     let term = run(input)?;
-    assert_eq!(Term::Lit(Literal::Number(3628800)), term);
+    assert_eq!(Term::Lit(3_628_800), term);
     Ok(())
 }
 
@@ -37,7 +36,7 @@ fn factorial() -> LangResult<'static, ()> {
 fn factorial_tail() -> LangResult<'static, ()> {
     let input = include_str!("factorial_tail.pj");
     let term = run(input)?;
-    assert_eq!(Term::Lit(Literal::Number(3628800)), term);
+    assert_eq!(Term::Lit(3_628_800), term);
     Ok(())
 }
 
@@ -45,7 +44,7 @@ fn factorial_tail() -> LangResult<'static, ()> {
 fn fancy_max() -> LangResult<'static, ()> {
     let input = include_str!("fancy_max.pj");
     let term = run(input)?;
-    assert_eq!(Term::Lit(Literal::Number(10)), term);
+    assert_eq!(Term::Lit(10), term);
     Ok(())
 }
 
@@ -53,7 +52,7 @@ fn fancy_max() -> LangResult<'static, ()> {
 fn fibonacci() -> LangResult<'static, ()> {
     let input = include_str!("fibonacci.pj");
     let term = run(input)?;
-    assert_eq!(Term::Lit(Literal::Number(21)), term);
+    assert_eq!(Term::Lit(21), term);
     Ok(())
 }
 
@@ -61,7 +60,7 @@ fn fibonacci() -> LangResult<'static, ()> {
 fn fibonacci_tail() -> LangResult<'static, ()> {
     let input = include_str!("fibonacci_tail.pj");
     let term = run(input)?;
-    assert_eq!(Term::Lit(Literal::Number(21)), term);
+    assert_eq!(Term::Lit(21), term);
     Ok(())
 }
 
@@ -69,7 +68,7 @@ fn fibonacci_tail() -> LangResult<'static, ()> {
 fn gcd() -> LangResult<'static, ()> {
     let input = include_str!("gcd.pj");
     let term = run(input)?;
-    assert_eq!(Term::Lit(Literal::Number(1)), term);
+    assert_eq!(Term::Lit(1), term);
     Ok(())
 }
 
@@ -77,7 +76,7 @@ fn gcd() -> LangResult<'static, ()> {
 fn ackermann() -> LangResult<'static, ()> {
     let input = include_str!("ackermann.pj");
     let term = run(input)?;
-    assert_eq!(Term::Lit(Literal::Number(5)), term);
+    assert_eq!(Term::Lit(5), term);
     Ok(())
 }
 
@@ -85,7 +84,7 @@ fn ackermann() -> LangResult<'static, ()> {
 fn calling() -> LangResult<'static, ()> {
     let input = include_str!("calling.pj");
     let term = run(input)?;
-    assert_eq!(Term::Lit(Literal::Number(1)), term);
+    assert_eq!(Term::Lit(1), term);
     Ok(())
 }
 
@@ -93,7 +92,7 @@ fn calling() -> LangResult<'static, ()> {
 fn complex_calling() -> LangResult<'static, ()> {
     let input = include_str!("complex_calling.pj");
     let term = run(input)?;
-    assert_eq!(Term::Lit(Literal::Number(1)), term);
+    assert_eq!(Term::Lit(1), term);
     Ok(())
 }
 
@@ -101,7 +100,7 @@ fn complex_calling() -> LangResult<'static, ()> {
 fn step() -> LangResult<'static, ()> {
     let input = include_str!("step.pj");
     let term = run(input)?;
-    assert_eq!(Term::Lit(Literal::Number(1)), term);
+    assert_eq!(Term::Lit(1), term);
     Ok(())
 }
 
@@ -109,7 +108,7 @@ fn step() -> LangResult<'static, ()> {
 fn bit_and() -> LangResult<'static, ()> {
     let input = include_str!("bit_and.pj");
     let term = run(input)?;
-    assert_eq!(Term::Lit(Literal::Number(64)), term);
+    assert_eq!(Term::Lit(64), term);
     Ok(())
 }
 
@@ -117,7 +116,7 @@ fn bit_and() -> LangResult<'static, ()> {
 fn bit_or() -> LangResult<'static, ()> {
     let input = include_str!("bit_or.pj");
     let term = run(input)?;
-    assert_eq!(Term::Lit(Literal::Number(192)), term);
+    assert_eq!(Term::Lit(192), term);
     Ok(())
 }
 
@@ -125,7 +124,7 @@ fn bit_or() -> LangResult<'static, ()> {
 fn bit_xor() -> LangResult<'static, ()> {
     let input = include_str!("bit_xor.pj");
     let term = run(input)?;
-    assert_eq!(Term::Lit(Literal::Number(128)), term);
+    assert_eq!(Term::Lit(128), term);
     Ok(())
 }
 
@@ -133,7 +132,7 @@ fn bit_xor() -> LangResult<'static, ()> {
 fn bit_shift_l() -> LangResult<'static, ()> {
     let input = include_str!("bit_shift_l.pj");
     let term = run(input)?;
-    assert_eq!(Term::Lit(Literal::Number(128)), term);
+    assert_eq!(Term::Lit(128), term);
     Ok(())
 }
 
@@ -141,7 +140,7 @@ fn bit_shift_l() -> LangResult<'static, ()> {
 fn bit_shift_r() -> LangResult<'static, ()> {
     let input = include_str!("bit_shift_r.pj");
     let term = run(input)?;
-    assert_eq!(Term::Lit(Literal::Number(32)), term);
+    assert_eq!(Term::Lit(32), term);
     Ok(())
 }
 
@@ -150,7 +149,7 @@ fn or_short_circuit() -> LangResult<'static, ()> {
     panic_after(Duration::from_secs(1), || {
         let input = include_str!("or_short_circuit.pj");
         let term = run(input)?;
-        assert_eq!(Term::Lit(Literal::Bool(true)), term);
+        assert_eq!(Term::Lit(1), term);
         Ok(())
     })
 }
@@ -160,7 +159,7 @@ fn and_short_circuit() -> LangResult<'static, ()> {
     panic_after(Duration::from_secs(1), || {
         let input = include_str!("and_short_circuit.pj");
         let term = run(input)?;
-        assert_eq!(Term::Lit(Literal::Bool(false)), term);
+        assert_eq!(Term::Lit(0), term);
         Ok(())
     })
 }
@@ -177,7 +176,7 @@ fn print_simple() -> LangResult<'static, ()> {
     )?;
     let output = String::from_utf8_lossy(&output);
     assert_eq!(output, "10\n");
-    assert_eq!(Term::Lit(Literal::Unit), term);
+    assert_eq!(Term::Lit(0), term);
     Ok(())
 }
 
@@ -193,7 +192,7 @@ fn print_simple_fn() -> LangResult<'static, ()> {
     )?;
     let output = String::from_utf8_lossy(&output);
     assert_eq!(output, "((λ. _0) 10)\n");
-    assert_eq!(Term::Lit(Literal::Unit), term);
+    assert_eq!(Term::Lit(0), term);
     Ok(())
 }
 
@@ -209,7 +208,7 @@ fn print_complex_fn() -> LangResult<'static, ()> {
     )?;
     let output = String::from_utf8_lossy(&output);
     assert_eq!(output, "((λ. (if (_0 > 0) then 1 else 0)) 10)\n");
-    assert_eq!(Term::Lit(Literal::Unit), term);
+    assert_eq!(Term::Lit(0), term);
     Ok(())
 }
 
@@ -225,7 +224,7 @@ fn print_print() -> LangResult<'static, ()> {
     )?;
     let output = String::from_utf8_lossy(&output);
     assert_eq!(output, "(print 10)\n");
-    assert_eq!(Term::Lit(Literal::Unit), term);
+    assert_eq!(Term::Lit(0), term);
     Ok(())
 }
 
@@ -240,7 +239,7 @@ fn print_redefine() {
 fn number_bases_cmp() -> LangResult<'static, ()> {
     let input = include_str!("number_bases_cmp.pj");
     let term = run(input)?;
-    assert_eq!(Term::Lit(Literal::Bool(true)), term);
+    assert_eq!(Term::Lit(1), term);
     Ok(())
 }
 
@@ -248,6 +247,6 @@ fn number_bases_cmp() -> LangResult<'static, ()> {
 fn number_bases_arithmetic() -> LangResult<'static, ()> {
     let input = include_str!("number_bases_arithmetic.pj");
     let term = run(input)?;
-    assert_eq!(Term::Lit(Literal::Number(567883 * 4)), term);
+    assert_eq!(Term::Lit(567_883 * 4), term);
     Ok(())
 }

--- a/tests/eval/mod.rs
+++ b/tests/eval/mod.rs
@@ -1,6 +1,7 @@
 use std::{include_str, time::Duration};
 
 use pijama::{
+    ast::Literal,
     lir::Term,
     machine::{LangEnv, Machine},
     run, run_with_machine, LangError, LangResult,
@@ -20,7 +21,7 @@ fn arithmetic() -> LangResult<'static, ()> {
 fn logic() -> LangResult<'static, ()> {
     let input = include_str!("logic.pj");
     let term = run(input)?;
-    assert_eq!(Term::Lit(0), term);
+    assert_eq!(term, false.into());
     Ok(())
 }
 
@@ -149,7 +150,7 @@ fn or_short_circuit() -> LangResult<'static, ()> {
     panic_after(Duration::from_secs(1), || {
         let input = include_str!("or_short_circuit.pj");
         let term = run(input)?;
-        assert_eq!(Term::Lit(1), term);
+        assert_eq!(term, true.into());
         Ok(())
     })
 }
@@ -159,7 +160,7 @@ fn and_short_circuit() -> LangResult<'static, ()> {
     panic_after(Duration::from_secs(1), || {
         let input = include_str!("and_short_circuit.pj");
         let term = run(input)?;
-        assert_eq!(Term::Lit(0), term);
+        assert_eq!(term, false.into());
         Ok(())
     })
 }
@@ -176,7 +177,7 @@ fn print_simple() -> LangResult<'static, ()> {
     )?;
     let output = String::from_utf8_lossy(&output);
     assert_eq!(output, "10\n");
-    assert_eq!(Term::Lit(0), term);
+    assert_eq!(term, Literal::Unit.into());
     Ok(())
 }
 
@@ -192,7 +193,7 @@ fn print_simple_fn() -> LangResult<'static, ()> {
     )?;
     let output = String::from_utf8_lossy(&output);
     assert_eq!(output, "((λ. _0) 10)\n");
-    assert_eq!(Term::Lit(0), term);
+    assert_eq!(term, Literal::Unit.into());
     Ok(())
 }
 
@@ -208,7 +209,7 @@ fn print_complex_fn() -> LangResult<'static, ()> {
     )?;
     let output = String::from_utf8_lossy(&output);
     assert_eq!(output, "((λ. (if (_0 > 0) then 1 else 0)) 10)\n");
-    assert_eq!(Term::Lit(0), term);
+    assert_eq!(term, Literal::Unit.into());
     Ok(())
 }
 
@@ -224,7 +225,7 @@ fn print_print() -> LangResult<'static, ()> {
     )?;
     let output = String::from_utf8_lossy(&output);
     assert_eq!(output, "(print 10)\n");
-    assert_eq!(Term::Lit(0), term);
+    assert_eq!(term, Literal::Unit.into());
     Ok(())
 }
 
@@ -239,7 +240,7 @@ fn print_redefine() {
 fn number_bases_cmp() -> LangResult<'static, ()> {
     let input = include_str!("number_bases_cmp.pj");
     let term = run(input)?;
-    assert_eq!(Term::Lit(1), term);
+    assert_eq!(term, true.into());
     Ok(())
 }
 


### PR DESCRIPTION
Quick implementation of #85 to test performance.

Result... it didn't change much 🤷‍♂️ 
```
arithmetic              time:   [22.695 us 22.785 us 22.888 us]
                        change: [-4.1061% -2.9098% -1.7925%] (p = 0.00 < 0.05)
logic                   time:   [39.303 us 39.418 us 39.539 us]
                        change: [-6.4213% -4.5619% -2.9174%] (p = 0.00 < 0.05)
factorial               time:   [79.233 us 79.825 us 80.490 us]
                        change: [+1.0349% +2.7375% +4.3128%] (p = 0.00 < 0.05)
factorial_tail          time:   [137.96 us 139.26 us 140.71 us]
                        change: [-9.5111% -8.0044% -6.3024%] (p = 0.00 < 0.05)
fibonacci               time:   [663.75 us 667.71 us 672.02 us]
                        change: [+1.1557% +2.4893% +3.9637%] (p = 0.00 < 0.05)
fibonacci_tail          time:   [126.43 us 127.51 us 128.65 us]
                        change: [-2.0285% -0.4566% +1.0984%] (p = 0.57 > 0.05)
gcd                     time:   [786.00 us 793.61 us 802.49 us]
                        change: [-2.6906% -1.0504% +0.5177%] (p = 0.22 > 0.05)
ackermann               time:   [498.72 us 503.78 us 509.44 us]
                        change: [-3.6419% -1.5418% +0.6650%] (p = 0.17 > 0.05)
calling                 time:   [148.71 us 150.53 us 152.54 us]
                        change: [+0.1352% +2.3095% +5.0439%] (p = 0.05 > 0.05)
complex_calling         time:   [160.16 us 161.90 us 163.76 us]
                        change: [-8.7673% -7.1075% -5.4440%] (p = 0.00 < 0.05)
fancy_max               time:   [3.1225 us 3.1541 us 3.1888 us]
                        change: [-1.9971% +0.6634% +3.4098%] (p = 0.65 > 0.05)
step                    time:   [2.3160 us 2.3396 us 2.3650 us]
                        change: [-4.0688% -1.9811% +0.2041%] (p = 0.08 > 0.05)
```