### PR TITLE
Use structopt to fetch command-line options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ nom_locate = "2.0.0"
 thiserror = "1.0"
 codespan-reporting = "0.9.4"
 lazy_static = "1.4.0"
+structopt = "0.3.14"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod machine;
 pub mod mir;
 pub mod parser;
 pub mod ty;
+pub mod options;
 
 use std::io::Write;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,22 @@
-use std::{env::args, fs::read_to_string};
+use std::fs::read_to_string;
 
-use pijama::{display_error, run};
+use pijama::{display_error, options::Options, run};
+
+use structopt::StructOpt;
 
 fn main() {
-    let mut args = args();
-    args.next().unwrap();
-    let path = args.next().expect("no path to source code");
-    let input = read_to_string(&path).unwrap();
+    let options = Options::from_args();
+
+    let input = match read_to_string(&options.path) {
+        Ok(input) => input,
+        Err(err) => {
+            eprintln!("{}", err);
+            return ();
+        }
+    };
+
     match run(&input) {
         Ok(term) => println!("{}", term),
-        Err(e) => display_error(&input, &path, &e),
+        Err(err) => display_error(&input, &options.path, &err),
     }
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,0 +1,8 @@
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+#[structopt(name = "pijama", about = "The Pijama compiler")]
+pub struct Options {
+    #[structopt(name = "INPUT", help = "Path to the input file.")]
+    pub path: String,
+}


### PR DESCRIPTION
This PR adds `structopt` to handle command-line arguments. This adds enough scaffolding to start working on https://github.com/christianpoveda/pijama/issues/78.

cc @DarkDrek 