### PR TITLE
Change lazy_static for once_cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ nom = "5.1.1"
 nom_locate = "2.0.0"
 thiserror = "1.0"
 codespan-reporting = "0.9.4"
-lazy_static = "1.4.0"
+once_cell = "1.4.0"
 pijama_ast = { path = "src/pijama_ast", version = "0.1.0" }
 structopt = "0.3.14"
 

--- a/src/parser/primitive.rs
+++ b/src/parser/primitive.rs
@@ -9,7 +9,7 @@ use nom::{
     multi::separated_nonempty_list,
 };
 
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 
 use std::collections::HashMap;
 
@@ -17,14 +17,12 @@ use pijama_ast::{Located, Primitive};
 
 use crate::parser::{IResult, Span};
 
-lazy_static! {
-    /// Words that are primitives.
-    pub static ref PRIMITIVES: HashMap<&'static str, Primitive> = {
-        let mut m = HashMap::new();
-        m.insert("print", Primitive::Print);
-        m
-    };
-}
+/// Words that are primitives.
+pub static PRIMITIVES: Lazy<HashMap<&'static str, Primitive>> = Lazy::new(|| {
+    let mut m = HashMap::new();
+    m.insert("print", Primitive::Print);
+    m
+});
 
 /// Parser for [`Primitive`]s.
 ///


### PR DESCRIPTION
This PR changes our lazy_static dependency for once_cell as the latter's API is more likely to be included in std: https://github.com/rust-lang/rfcs/pull/2788