### PR TITLE
Revamp `Location` and `Located`

### DIFF
--- a/src/parser/block.rs
+++ b/src/parser/block.rs
@@ -34,10 +34,7 @@ pub fn block0(input: Span) -> IResult<Located<Block>> {
             separated_list(line_ending, preceded(multispace0, node)),
             position,
         )),
-        |(sp1, content, sp2)| {
-            let loc = Location::from(sp1) + Location::from(sp2);
-            Located::new(content, loc)
-        },
+        |(sp1, content, sp2)| (Location::from(sp1) + Location::from(sp2)).with_content(content),
     )(input)
 }
 
@@ -56,9 +53,6 @@ pub fn block1(input: Span) -> IResult<Located<Block>> {
             separated_nonempty_list(line_ending, preceded(multispace0, node)),
             position,
         )),
-        |(sp1, content, sp2)| {
-            let loc = Location::from(sp1) + Location::from(sp2);
-            Located::new(content, loc)
-        },
+        |(sp1, content, sp2)| (Location::from(sp1) + Location::from(sp2)).with_content(content),
     )(input)
 }

--- a/src/parser/helpers.rs
+++ b/src/parser/helpers.rs
@@ -41,10 +41,7 @@ pub fn in_brackets<'a, O: std::fmt::Debug, E: ParseError<Span<'a>>>(
             surrounded(content, multispace0),
             preceded(char(')'), position),
         )),
-        |(sp1, content, sp2)| {
-            let loc = Location::new(sp1.location_offset(), sp2.location_offset() + 1);
-            Located::new(content, loc)
-        },
+        |(sp1, content, sp2)| (Location::from(sp1) + Location::from(sp2)).with_content(content),
     )
 }
 

--- a/src/parser/literal.rs
+++ b/src/parser/literal.rs
@@ -34,9 +34,7 @@ pub fn literal(input: Span) -> IResult<Located<Literal>> {
                 Located::new(Literal::Bool(false), span)
             }),
             map(tag("unit"), |span: Span| Located::new(Literal::Unit, span)),
-            map(number, |Located { content, loc }| {
-                Located::new(Literal::Number(content), loc)
-            }),
+            map(number, |located_num| located_num.map(Literal::Number)),
         )),
     )(input)
 }

--- a/src/parser/literal.rs
+++ b/src/parser/literal.rs
@@ -27,13 +27,11 @@ pub fn literal(input: Span) -> IResult<Located<Literal>> {
     with_context(
         "Expected literal (true, false, unit) or number",
         alt((
-            map(tag("true"), |span: Span| {
-                Located::new(Literal::Bool(true), span)
-            }),
-            map(tag("false"), |span: Span| {
+            map(tag("true"), |span| Located::new(Literal::Bool(true), span)),
+            map(tag("false"), |span| {
                 Located::new(Literal::Bool(false), span)
             }),
-            map(tag("unit"), |span: Span| Located::new(Literal::Unit, span)),
+            map(tag("unit"), |span| Located::new(Literal::Unit, span)),
             map(number, |located_num| located_num.map(Literal::Number)),
         )),
     )(input)
@@ -81,7 +79,7 @@ fn number(input: Span) -> IResult<Located<i64>> {
             let number = i64::from_str_radix(&number, radix).ok()?;
             let loc = Location::from(position) + digits_span.into();
 
-            Some(Located::new(number, loc))
+            Some(loc.with_content(number))
         },
     )(input)
 }

--- a/src/parser/node/call.rs
+++ b/src/parser/node/call.rs
@@ -37,6 +37,6 @@ pub fn call(input: Span) -> IResult<Located<Node>> {
     ));
     map(separated_pair(func, space0, args(node)), |(func, args)| {
         let loc = func.loc + args.loc;
-        Located::new(Node::Call(Box::new(func), args.content), loc)
+        loc.with_content(Node::Call(Box::new(func), args.content))
     })(input)
 }

--- a/src/parser/node/call.rs
+++ b/src/parser/node/call.rs
@@ -28,12 +28,8 @@ use crate::parser::{
 /// the `=`.
 pub fn call(input: Span) -> IResult<Located<Node>> {
     let func = alt((
-        map(name, |Located { content, loc }| {
-            Located::new(Node::Name(content), loc)
-        }),
-        map(primitive, |Located { content, loc }| {
-            Located::new(Node::PrimFn(content), loc)
-        }),
+        map(name, |located_name| located_name.map(Node::Name)),
+        map(primitive, |located_prim| located_prim.map(Node::PrimFn)),
         map(in_brackets(node), |Located { mut content, loc }| {
             content.loc = loc;
             content

--- a/src/parser/node/fn_def.rs
+++ b/src/parser/node/fn_def.rs
@@ -49,12 +49,9 @@ pub fn fn_def(input: Span) -> IResult<Located<Node>> {
             fn_body,
         )),
         |(name, args, opt_ty, body)| {
-            let loc1 = name.loc;
-            let loc2 = body.loc;
-            Located::new(
-                Node::FnDef(name.content, args.content, body.content, opt_ty),
-                loc1 + loc2,
-            )
+            name.zip_with(body, move |name, body| {
+                Node::FnDef(name, args.content, body, opt_ty)
+            })
         },
     )(input)
 }

--- a/src/parser/node/fn_def.rs
+++ b/src/parser/node/fn_def.rs
@@ -70,7 +70,7 @@ fn fn_name(input: Span) -> IResult<Located<Option<Located<Name>>>> {
             if let Some(name) = opt_name.as_ref() {
                 loc = loc + name.loc;
             }
-            Located::new(opt_name, loc)
+            loc.with_content(opt_name)
         },
     )(input)
 }
@@ -109,10 +109,6 @@ fn fn_body(input: Span) -> IResult<Located<Located<Block>>> {
             block0,
             preceded(pair(multispace0, keyword("end")), position),
         )),
-        |(sp1, content, sp2)| {
-            let loc1 = Location::from(sp1);
-            let loc2 = Location::from(sp2);
-            Located::new(content, loc1 + loc2)
-        },
+        |(sp1, content, sp2)| Located::new(content, Location::from(sp1) + Location::from(sp2)),
     )(input)
 }

--- a/src/pijama_ast/src/location/mod.rs
+++ b/src/pijama_ast/src/location/mod.rs
@@ -25,6 +25,10 @@ impl Location {
     pub const fn new(start: usize, end: usize) -> Self {
         Location { start, end }
     }
+    /// Creates a new `Located` consuming this `Location`.
+    pub fn with_content<T: Debug>(self, content: T) -> Located<T> {
+        Located::new(content, self)
+    }
 }
 
 /// Adding two locations `l1` and `l2` returns a location starting in `l1.start` and ending in
@@ -70,8 +74,12 @@ impl<T: Debug> Located<T> {
             loc: self.loc,
         })
     }
-    /// Joins two `Located` by adding their locations and joining their contents using a closure.
-    pub fn zip_with<U: Debug, V: Debug, F: FnOnce(T, U) -> V>(self, other: Located<U>, f: F) -> Located<V> {
+    /// Joins two `Located`s by adding their locations and joining their contents using a closure.
+    pub fn zip_with<U: Debug, V: Debug, F: FnOnce(T, U) -> V>(
+        self,
+        other: Located<U>,
+        f: F,
+    ) -> Located<V> {
         Located {
             content: f(self.content, other.content),
             loc: self.loc + other.loc,


### PR DESCRIPTION
This PR adds new methods to `pijama_ast`s `Location` and `Located` types to be more easy to use and combine.