### PR TITLE
Move Span use to correct crate

### DIFF
--- a/src/parser/bin_op.rs
+++ b/src/parser/bin_op.rs
@@ -16,11 +16,11 @@ use nom::{
     sequence::terminated,
 };
 
-use pijama_ast::{BinOp, BinOp::*};
+use pijama_ast::{BinOp, BinOp::*, Span};
 
 use crate::parser::{
     helpers::{surrounded, with_context},
-    IResult, Span,
+    IResult,
 };
 
 /// Parser for the binary operators with precedence level 1.

--- a/src/parser/block.rs
+++ b/src/parser/block.rs
@@ -12,11 +12,11 @@ use nom::{
 
 use nom_locate::position;
 
-use pijama_ast::{Block, Located, Location};
+use pijama_ast::{Block, Located, Location, Span};
 
 use crate::parser::{
     node::{comment, node},
-    IResult, Span,
+    IResult,
 };
 
 /// Parser for [`Block`]s which may or may not be empty.

--- a/src/parser/helpers.rs
+++ b/src/parser/helpers.rs
@@ -10,9 +10,9 @@ use nom::{
 };
 use nom_locate::position;
 
-use pijama_ast::{Located, Location};
+use pijama_ast::{Located, Location, Span};
 
-use crate::parser::{ParsingError, Span};
+use crate::parser::ParsingError;
 
 use std::fmt::Display;
 

--- a/src/parser/literal.rs
+++ b/src/parser/literal.rs
@@ -10,9 +10,9 @@ use nom::{
 };
 use nom_locate::position;
 
-use pijama_ast::{Literal, Located, Location};
+use pijama_ast::{Literal, Located, Location, Span};
 
-use crate::parser::{helpers::with_context, IResult, Span};
+use crate::parser::{helpers::with_context, IResult};
 
 use std::borrow::Cow;
 

--- a/src/parser/name.rs
+++ b/src/parser/name.rs
@@ -9,9 +9,9 @@ use nom::{
     multi::separated_nonempty_list,
 };
 
-use pijama_ast::{Located, Name};
+use pijama_ast::{Located, Name, Span};
 
-use crate::parser::{primitive::PRIMITIVES, IResult, Span};
+use crate::parser::{primitive::PRIMITIVES, IResult};
 
 /// Words that cannot be names to avoid ambiguities.
 const KEYWORDS: &[&str] = &[

--- a/src/parser/node/binary_op.rs
+++ b/src/parser/node/binary_op.rs
@@ -47,9 +47,9 @@ use nom::{
     sequence::pair,
 };
 
-use pijama_ast::{Located, Node};
+use pijama_ast::{Located, Node, Span};
 
-use crate::parser::{bin_op::*, node::base_node, IResult, Span};
+use crate::parser::{bin_op::*, node::base_node, IResult};
 
 /// Parses a [`Node::BinaryOp`].
 pub fn binary_op(input: Span) -> IResult<Located<Node>> {

--- a/src/parser/node/call.rs
+++ b/src/parser/node/call.rs
@@ -8,14 +8,14 @@
 //! ```
 use nom::{branch::alt, character::complete::space0, combinator::map, sequence::separated_pair};
 
-use pijama_ast::{Located, Node};
+use pijama_ast::{Located, Node, Span};
 
 use crate::parser::{
     helpers::in_brackets,
     name::name,
     node::{fn_def::args, node},
     primitive::primitive,
-    IResult, Span,
+    IResult,
 };
 
 /// Parses a [`Node::Call`].

--- a/src/parser/node/comment.rs
+++ b/src/parser/node/comment.rs
@@ -9,7 +9,9 @@ use nom::{
     sequence::delimited,
 };
 
-use crate::parser::{IResult, Span};
+use pijama_ast::Span;
+
+use crate::parser::IResult;
 
 /// Parses a comment, returning () if it finds one.
 pub fn comment(input: Span) -> IResult<()> {

--- a/src/parser/node/cond.rs
+++ b/src/parser/node/cond.rs
@@ -17,12 +17,12 @@ use nom::{
 };
 use nom_locate::position;
 
-use pijama_ast::{Block, Branch, Located, Location, Node};
+use pijama_ast::{Block, Branch, Located, Location, Node, Span};
 
 use crate::parser::{
     block::block1,
     helpers::{keyword, keyword_space},
-    IResult, Span,
+    IResult,
 };
 
 /// Parses a [`Node::Cond`].

--- a/src/parser/node/fn_def.rs
+++ b/src/parser/node/fn_def.rs
@@ -21,14 +21,14 @@ use nom::{
 };
 use nom_locate::position;
 
-use pijama_ast::{Block, Located, Location, Name, Node};
+use pijama_ast::{Block, Located, Location, Name, Node, Span};
 
 use crate::parser::{
     block::block0,
     helpers::{in_brackets, keyword, keyword_space, surrounded},
     name::name,
     ty::{colon_ty, ty_annotation},
-    IResult, Span,
+    IResult,
 };
 
 /// Parses a [`Node::FnDef`].

--- a/src/parser/node/let_bind.rs
+++ b/src/parser/node/let_bind.rs
@@ -14,9 +14,9 @@ use nom::{
     sequence::{preceded, tuple},
 };
 
-use pijama_ast::{Located, Node};
+use pijama_ast::{Located, Node, Span};
 
-use crate::parser::{helpers::surrounded, name::name, node::node, ty::colon_ty, IResult, Span};
+use crate::parser::{helpers::surrounded, name::name, node::node, ty::colon_ty, IResult};
 
 /// Parses a [`Node::LetBind`].
 ///

--- a/src/parser/node/mod.rs
+++ b/src/parser/node/mod.rs
@@ -22,7 +22,7 @@ use nom::{
     sequence::pair,
 };
 
-use pijama_ast::{Located, Node};
+use pijama_ast::{Located, Node, Span};
 
 use crate::parser::{
     helpers::{in_brackets, lookahead},
@@ -30,7 +30,7 @@ use crate::parser::{
     name::name,
     primitive::primitive,
     un_op::un_op,
-    IResult, Span,
+    IResult,
 };
 
 /// Parser for [`Node`]s.

--- a/src/parser/node/unary_op.rs
+++ b/src/parser/node/unary_op.rs
@@ -7,9 +7,9 @@
 use nom::{combinator::map, sequence::tuple};
 use nom_locate::position;
 
-use pijama_ast::{Located, Location, Node};
+use pijama_ast::{Located, Location, Node, Span};
 
-use crate::parser::{node::node, un_op::un_op, IResult, Span};
+use crate::parser::{node::node, un_op::un_op, IResult};
 
 /// Parses a [`Node::UnaryOp`].
 ///

--- a/src/parser/primitive.rs
+++ b/src/parser/primitive.rs
@@ -13,9 +13,9 @@ use once_cell::sync::Lazy;
 
 use std::collections::HashMap;
 
-use pijama_ast::{Located, Primitive};
+use pijama_ast::{Located, Primitive, Span};
 
-use crate::parser::{IResult, Span};
+use crate::parser::IResult;
 
 /// Words that are primitives.
 pub static PRIMITIVES: Lazy<HashMap<&'static str, Primitive>> = Lazy::new(|| {

--- a/src/parser/ty.rs
+++ b/src/parser/ty.rs
@@ -44,13 +44,13 @@ use nom::{
 
 use pijama_ast::{
     ty::{Ty, TyAnnotation},
-    Located,
+    Located, Span,
 };
 
 use crate::parser::{
     helpers::{in_brackets, surrounded, with_context},
     name::name,
-    IResult, Span,
+    IResult,
 };
 
 /// Parser for all types.

--- a/src/parser/un_op.rs
+++ b/src/parser/un_op.rs
@@ -11,9 +11,9 @@ use nom::{
     sequence::terminated,
 };
 
-use pijama_ast::{UnOp, UnOp::*};
+use pijama_ast::{Span, UnOp, UnOp::*};
 
-use crate::parser::{helpers::with_context, IResult, Span};
+use crate::parser::{helpers::with_context, IResult};
 
 /// Parser for the unary operators `!` and `-`.
 ///

--- a/src/pijama_ast/src/analysis/mod.rs
+++ b/src/pijama_ast/src/analysis/mod.rs
@@ -1,8 +1,8 @@
 //! Diverse checks that need to be done before lowering.
 use crate::{
+    ty::{Ty, TyAnnotation},
     visitor::{BlockRef, NodeVisitor},
     Block, Located, Name, Node,
-    ty::{TyAnnotation, Ty},
 };
 
 /// Checks if a function is recursive or not.

--- a/src/pijama_ast/src/lib.rs
+++ b/src/pijama_ast/src/lib.rs
@@ -1,11 +1,11 @@
-pub mod ty;
 pub mod analysis;
 pub mod location;
+pub mod ty;
 pub mod visitor;
 
 use std::fmt::{Debug, Display, Formatter, Result};
 
-use crate::ty::{TyAnnotation, Ty};
+use crate::ty::{Ty, TyAnnotation};
 
 pub use location::*;
 

--- a/src/pijama_ast/src/visitor/mod.rs
+++ b/src/pijama_ast/src/visitor/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
+    ty::{Ty, TyAnnotation},
     BinOp, Block, Branch, Literal, Located, Name, Node, Primitive, UnOp,
-    ty::{TyAnnotation, Ty},
 };
 
 /// Helper type alias to traverse references to blocks as slices.


### PR DESCRIPTION
In #95 the use of `Span` wasn't moved from `crate::parser::Span` to `pijama_ast::Span` it still compiles somehow??? with the wrong path but we should correct that.

I also think that `Span` shouldn't be in `pijama_ast` but in `pijama_parser` since it is tightly coupled with `nom` as a parser. This would require some more changes how `Location`s are created because then they would be in two different crates and can't simply implement `From` for them. It should be possible if we create an intermediate type or something like that. I can try doing this when we really want a complete separation of the crates?