### PR TITLE
Trigger evaluation when working with primitives

### DIFF
--- a/src/lir/mod.rs
+++ b/src/lir/mod.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use pijama_ast::*;
+use pijama_ast::{BinOp, Literal, Located, Primitive, UnOp};
 
 use Term::*;
 
@@ -78,6 +78,10 @@ impl fmt::Display for Term {
 impl Term {
     pub fn from_mir(mir: Located<crate::mir::Term>) -> Self {
         lower::remove_names(mir)
+    }
+
+    pub fn is_value(&self) -> bool {
+        matches!(self, Lit(_) | Abs(_) | PrimFn(_))
     }
 
     pub(crate) fn shift(&mut self, up: bool, cutoff: usize) {

--- a/src/lir/mod.rs
+++ b/src/lir/mod.rs
@@ -80,10 +80,6 @@ impl Term {
         lower::remove_names(mir)
     }
 
-    pub fn is_value(&self) -> bool {
-        matches!(self, Lit(_) | Abs(_) | PrimFn(_))
-    }
-
     pub(crate) fn shift(&mut self, up: bool, cutoff: usize) {
         match self {
             Lit(_) | PrimFn(_) | Hole => (),

--- a/src/machine/eval.rs
+++ b/src/machine/eval.rs
@@ -5,52 +5,50 @@ use crate::{
     machine::{arithmetic::Arithmetic, Machine},
 };
 
-use std::{
-    borrow::{Borrow, BorrowMut},
-    io::Write,
-};
+use std::{borrow::Borrow, io::Write};
 
 impl<W: Write, A: Arithmetic> Machine<W, A> {
+    pub(super) fn eval(&mut self, mut term: Term) -> (bool, Term) {
+        let mut changed = false;
+        while {
+            let (eval, new_term) = self.step(term);
+            term = new_term;
+            eval
+        } {
+            changed = true;
+        }
+        (changed, term)
+    }
+
     pub(super) fn step(&mut self, term: Term) -> (bool, Term) {
         match term {
             // Dispatch step for binary operations
             BinaryOp(op, t1, t2) => self.step_bin_op(op, t1, t2),
             // Dispatch step for unary operations
             UnaryOp(op, t1) => self.step_un_op(op, t1),
-            App(mut t1, mut arg) => match *t1 {
+            App(mut t1, arg) => match *t1 {
                 // Dispatch step for beta reduction
                 Abs(body) => self.step_beta_reduction(*body, arg),
-                // Dispatch step for primitive application if argument is evaluated
-                PrimFn(prim) if arg.is_value() => self.step_primitive_app(prim, arg),
-                // Evaluate argument if that's not the case.
-                PrimFn(_) => (self.step_in_place(arg.borrow_mut()), App(t1, arg)),
+                // Dispatch step for primitive application
+                PrimFn(prim) => self.step_primitive_app(prim, *arg),
                 // Application with unevaluated first term (t1 t2)
                 // Evaluate t1.
-                _ => (self.step_in_place(t1.borrow_mut()), App(t1, arg)),
+                _ => {
+                    let (changed, new_t1) = self.eval(*t1);
+                    *t1 = new_t1;
+                    (changed, App(t1, arg))
+                }
             },
             // Dispatch step for conditionals
-            Cond(t1, t2, t3) => self.step_conditional(t1, t2, t3),
+            Cond(t1, t2, t3) => self.step_cond(t1, t2, t3),
             // Dispatch step for fixed point operation
             Fix(t1) => self.step_fix(t1),
             // Any other term stops the evaluation.
             Var(_) | Lit(_) | Abs(_) | PrimFn(_) | Hole => (false, term),
         }
     }
-
-    fn step_in_place(&mut self, term: &mut Term) -> bool {
-        let inner_term = std::mem::replace(term, Hole);
-        let (cont, inner_term) = self.step(inner_term);
-        *term = inner_term;
-        cont
-    }
-
     /// Evaluation step for conditionals (if t1 then t2 else t3)
-    fn step_conditional(
-        &mut self,
-        mut t1: Box<Term>,
-        t2: Box<Term>,
-        t3: Box<Term>,
-    ) -> (bool, Term) {
+    fn step_cond(&mut self, mut t1: Box<Term>, t2: Box<Term>, t3: Box<Term>) -> (bool, Term) {
         // If t1 is a literal, we should be able to evaluate the conditional
         if let lit @ Term::Lit(_) = t1.borrow() {
             if lit.as_bool() {
@@ -62,15 +60,17 @@ impl<W: Write, A: Arithmetic> Machine<W, A> {
             }
         } else {
             // If t1 is not a literal, evaluate it in place and return (if t1 then t2 else t3)
-            (self.step_in_place(t1.borrow_mut()), Term::Cond(t1, t2, t3))
+            let (changed, new_t1) = self.eval(*t1);
+            *t1 = new_t1;
+            (changed, Term::Cond(t1, t2, t3))
         }
     }
 
     /// Evaluation step for binary operations (t1 op t2)
-    fn step_bin_op(&mut self, op: BinOp, mut a: Box<Term>, mut b: Box<Term>) -> (bool, Term) {
+    fn step_bin_op(&mut self, op: BinOp, mut t1: Box<Term>, mut t2: Box<Term>) -> (bool, Term) {
         use BinOp::*;
 
-        match (op, a.borrow(), b.borrow()) {
+        match (op, t1.borrow(), t2.borrow()) {
             // If op is && and t1 is false evaluate to false
             (And, Lit(0), _) => (true, false.into()),
             // If op is || and t1 is true evaluate to true
@@ -78,9 +78,17 @@ impl<W: Write, A: Arithmetic> Machine<W, A> {
             // If both are literals evaluate with native operation
             (_, Lit(l1), Lit(l2)) => (true, Lit(A::binary_operation(op, *l1, *l2))),
             // If t2 is not a literal, evaluate it.
-            (_, Lit(_), _) => (self.step_in_place(b.borrow_mut()), Term::BinaryOp(op, a, b)),
+            (_, Lit(_), _) => {
+                let (changed, new_t2) = self.eval(*t2);
+                *t2 = new_t2;
+                (changed, Term::BinaryOp(op, t1, t2))
+            }
             // If t1 is not a literal, evaluate it.
-            _ => (self.step_in_place(a.borrow_mut()), Term::BinaryOp(op, a, b)),
+            _ => {
+                let (changed, new_t1) = self.eval(*t1);
+                *t1 = new_t1;
+                (changed, Term::BinaryOp(op, t1, t2))
+            }
         }
     }
 
@@ -91,7 +99,9 @@ impl<W: Write, A: Arithmetic> Machine<W, A> {
             (true, Term::Lit(A::unary_operation(op, *lit)))
         // If t1 is not a literal, evaluate it.
         } else {
-            (self.step_in_place(&mut t1), Term::UnaryOp(op, t1))
+            let (changed, new_t1) = self.eval(*t1);
+            *t1 = new_t1;
+            (changed, Term::UnaryOp(op, t1))
         }
     }
 
@@ -105,7 +115,9 @@ impl<W: Write, A: Arithmetic> Machine<W, A> {
             (true, *t2)
         // If t1 is not an abstraction, evaluate it.
         } else {
-            (self.step_in_place(&mut t1), Term::Fix(t1))
+            let (changed, new_t1) = self.eval(*t1);
+            *t1 = new_t1;
+            (changed, Term::Fix(t1))
         }
     }
 
@@ -122,9 +134,11 @@ impl<W: Write, A: Arithmetic> Machine<W, A> {
         (true, body)
     }
     /// Evaluation step for application of primitive functions (prim arg)
-    fn step_primitive_app(&mut self, prim: Primitive, arg: Box<Term>) -> (bool, Term) {
+    fn step_primitive_app(&mut self, prim: Primitive, arg: Term) -> (bool, Term) {
         match prim {
             Primitive::Print => {
+                // Evaluate argument
+                let (_, arg) = self.eval(arg);
                 writeln!(self.env.stdout(), "{}", arg).expect("Primitive print failed");
                 (true, Literal::Unit.into())
             }

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -18,12 +18,7 @@ pub struct Machine<W: Write, A: Arithmetic> {
 }
 
 impl<W: Write, A: Arithmetic> Machine<W, A> {
-    pub fn evaluate(&mut self, mut term: Term) -> Term {
-        while {
-            let (eval, new_term) = self.step(term);
-            term = new_term;
-            eval
-        } {}
-        term
+    pub fn evaluate(&mut self, term: Term) -> Term {
+        self.eval(term).1
     }
 }

--- a/tests/eval/mod.rs
+++ b/tests/eval/mod.rs
@@ -185,7 +185,7 @@ fn print_simple_fn() -> LangResult<'static, ()> {
         machine_builder().with_env(Env::new(&mut output)).build(),
     )?;
     let output = String::from_utf8_lossy(&output);
-    assert_eq!(output, "((λ. _0) 10)\n");
+    assert_eq!(output, "(λ. _0)\n");
     assert_eq!(term, Literal::Unit.into());
     Ok(())
 }
@@ -199,7 +199,7 @@ fn print_complex_fn() -> LangResult<'static, ()> {
         machine_builder().with_env(Env::new(&mut output)).build(),
     )?;
     let output = String::from_utf8_lossy(&output);
-    assert_eq!(output, "((λ. (if (_0 > 0) then 1 else 0)) 10)\n");
+    assert_eq!(output, "1\n");
     assert_eq!(term, Literal::Unit.into());
     Ok(())
 }
@@ -213,7 +213,7 @@ fn print_print() -> LangResult<'static, ()> {
         machine_builder().with_env(Env::new(&mut output)).build(),
     )?;
     let output = String::from_utf8_lossy(&output);
-    assert_eq!(output, "(print 10)\n");
+    assert_eq!(output, "10\n0\n");
     assert_eq!(term, Literal::Unit.into());
     Ok(())
 }

--- a/tests/eval/print_simple_fn.pj
+++ b/tests/eval/print_simple_fn.pj
@@ -2,4 +2,4 @@ fn foo(x: Int) do
     x
 end
 
-print(foo(10))
+print(foo)


### PR DESCRIPTION
This PR changes our evaluation strategy to force evaluation when a primitive function is applied over a term.

cc @DarkDrek 