### PR TITLE
New backend for Pijama

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "pijama_mir",
     "pijama_tycheck",
     "pijama_lir",
+    "pijama_llama",
     "pijama_machine",
     "pijama_driver",
     "pijama",

--- a/pijama_driver/Cargo.toml
+++ b/pijama_driver/Cargo.toml
@@ -11,6 +11,7 @@ pijama_parser = { path = "../pijama_parser" }
 pijama_ty = { path = "../pijama_ty" }
 pijama_mir = { path = "../pijama_mir" }
 pijama_tycheck = { path = "../pijama_tycheck" }
+pijama_llama = { path = "../pijama_llama" }
 pijama_lir = { path = "../pijama_lir" }
 pijama_machine = { path = "../pijama_machine" }
 

--- a/pijama_driver/src/lib.rs
+++ b/pijama_driver/src/lib.rs
@@ -34,6 +34,10 @@ pub fn run_with_machine<W: Write, A: Arithmetic>(
     let ast = parse(input)?;
     let mir = MirTerm::from_ast(ast)?;
     let _ty = ty_check(&mir)?;
+
+    let llama = pijama_llama::lower(&mir);
+    dbg!(llama);
+
     let lir = LirTerm::from_mir(mir);
     let _res = machine.evaluate(lir);
     Ok(())

--- a/pijama_llama/Cargo.toml
+++ b/pijama_llama/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "pijama_llama"
+version = "0.1.0"
+authors = ["The Pijama Project Developers"]
+edition = "2018"
+
+[dependencies]
+pijama_ast = { path = "../pijama_ast" }
+pijama_mir = { path = "../pijama_mir" }
+

--- a/pijama_llama/src/lib.rs
+++ b/pijama_llama/src/lib.rs
@@ -1,0 +1,6 @@
+use pijama_ast::location::Located;
+use pijama_mir::Term;
+
+pub fn lower(_term: &Located<Term>) {
+
+}


### PR DESCRIPTION
Pijama is alive!

After a long hiatus I am back with new ideas for the project. One of those is rewriting the language backend to a VM based model. The intermediate representations for these two are influenced by the [STG language](https://www.microsoft.com/en-us/research/wp-content/uploads/1992/04/spineless-tagless-gmachine.pdf) (Haskell) and [Lox's VM](http://craftinginterpreters.com/a-bytecode-virtual-machine.html) (Crafting interpreters).

So this PR (or series of PRs, we'll see) will include:
- [ ] A new IR (Llama) based on the STG language.
- [ ] A bytecode generator which takes the Llama code as input.
- [ ] A bytecode VM that takes care of actually executing the program-